### PR TITLE
Support for ledger xpub export

### DIFF
--- a/src/ledger.js
+++ b/src/ledger.js
@@ -9,6 +9,7 @@ import {
   NETWORKS,
   MULTISIG_ADDRESS_TYPES,
   multisigAddressType,
+  bip32PathToSequence
 } from "unchained-bitcoin";
 
 import {
@@ -20,6 +21,7 @@ import {
 } from "./interaction";
 
 const bitcoin = require('bitcoinjs-lib');
+const bip32 = require('bip32');
 
 const TransportU2F = require("@ledgerhq/hw-transport-u2f").default;
 const LedgerBtc    = require("@ledgerhq/hw-app-btc").default;
@@ -109,14 +111,29 @@ export class LedgerExportPublicKey extends LedgerExportHDNode {
 
 }
 
+/**
+ * Class for wallet extended public key(xpub) interaction at a given BIP32 path.
+ * @extends {module:ledger.LedgerExportHDNode}
+ */
 export class LedgerExportExtendedPublicKey extends LedgerExportHDNode {
 
+  /**
+   * Retrieve extended public key(xpub) from Ledger device for a given instance
+   * @example
+   * const ledgerXpubExporter = new LedgerExportExtendedPublicKey({network, bip32Path});
+   * const xpub = await ledgerXpubExporter.run();
+   * console.log(xpub);
+   * @returns {string} extended public key(xpub) for the BIP32 path of a given instance
+   */
   async run() {
-    /*const result = */await super.run();
-    // FIXME
-    return {error: "Unable to export extended public key."};
+    const walletPublicKey = await super.run();
+    const transport = await TransportU2F.create();
+    const ledgerbtc = new LedgerBtc(transport);
+    const parentWalletPublicKey = await getParentWalletPublicKey(this.bip32Path, ledgerbtc);
+    const node = generateHDNode(parentWalletPublicKey, walletPublicKey, this.bip32Path);
+    node.network.bip32.public = isTestnet(this.network) ? 0x043587cf : 0x0488b21e; // TODO: export constants in unchained-bitcoin
+    return node.toBase58();
   }
-
 }
 
 /**
@@ -260,4 +277,37 @@ function ledgerInput(ledgerbtc, input) {
     return [tx, input.index, scriptToHex(multisigWitnessScript(input.multisig))];
   }
 
+}
+
+function generateHDNode(parentWalletPublicKey, childWalletPublicKey, bip32Path) {
+  // parentWalletPublicKey and childWalletPublicKey are data structures returned from getWalletPublicKey()
+  // ledger methods
+  // e.g. {publicKey: "048998c3655b16e1d74f6cab21651eb1be67394b2726356...,
+  //       bitcoinAddress: "1A92zVckrWBk1abTjBqndd3Axr7ijtuWd9",
+  //       chainCode: "8f16c9fc56caa5ece39b485c990e0f934146f4a9fa7bb0a...
+  //      }
+  const keyPath = bip32Path.split("/").slice(1).join("/"); // remove leading 'm/'
+
+  const node = getNodeForWalletPublicKey(childWalletPublicKey);
+  const parentNode = getNodeForWalletPublicKey(parentWalletPublicKey);
+
+  node.parentFingerprint = parentNode.fingerprint;
+  node.depth = keyPath.split("/").length - 1;
+  const sequence = bip32PathToSequence(keyPath);
+  node.index = sequence.slice(-1)[0];
+  node.path = keyPath;
+  return node;
+}
+
+function getNodeForWalletPublicKey(walletPublicKey) {
+  const compressedPublicKey = compressPublicKey(walletPublicKey.publicKey);
+  const node = bip32.fromPublicKey(Buffer.from(compressedPublicKey, 'hex'),
+    Buffer.from(walletPublicKey.chainCode, 'hex'));
+  return node;
+}
+
+async function getParentWalletPublicKey(bip32Path, ledgerbtc) {
+  const parentKeyPath = bip32Path.split("/").slice(1, -1).join("/");
+  const parentWalletPublicKey = await ledgerbtc.getWalletPublicKey(parentKeyPath, false);
+  return parentWalletPublicKey;
 }


### PR DESCRIPTION
This requires the retrieval of the parent public key so the node being exported will have the proper parent `parentFingerprint`.  An additional call is made to get the parent but skipping the verify since this is done in the call to `super`

See [this issue](https://github.com/LedgerHQ/ledgerjs/issues/156#issuecomment-422184943) for some context.  The call to retrieve the parent returns with the fingerprint, so no need to calculate.