### PR TITLE
Retrieve public keys for multiple addresses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,12 @@ export const TREZOR = 'trezor';
 export const LEDGER = 'ledger';
 export const HERMIT = 'hermit';
 
-export function HardwareWalletExportPublicKey({walletType, network, bip32Path}) {
+export function HardwareWalletExportPublicKey({walletType, network, bip32Path, bip32Paths}) {
   switch (walletType) {
   case TREZOR:
-    return new TrezorExportPublicKey({network, bip32Path});
+    return new TrezorExportPublicKey({network, bip32Path, bip32Paths});
   case LEDGER:
-    return new LedgerExportPublicKey({network, bip32Path});
+    return new LedgerExportPublicKey({network, bip32Path, bip32Paths});
   default:
     return new UnsupportedInteraction({network, failureCode: "unsupported", failureText: "This wallet is not supported when exporting public keys."});
   }

--- a/src/trezor.js
+++ b/src/trezor.js
@@ -109,7 +109,7 @@ export class TrezorExportHDNode extends TrezorInteraction {
    * const trezorNode = new TrezorExportHDNode({network: "mainnet", bip32Path: "m/48'/0'/0'/2'/0"});
    * const result = await trezorNode.run();
    * console.log(result.publicKey);
-   * @returns {object} object containing public key and extended public key for the BIP32 path of a given instance
+   * @returns {Object|Array<object>} object or array of objects containing public key and extended public key for the BIP32 path of a given instance
    */
   async run() {
     let result;
@@ -146,7 +146,7 @@ export class TrezorExportPublicKey extends TrezorExportHDNode {
    * const trezorNode = new TrezorExportPublicKey({network: "mainnet", bip32Path: "m/48'/0'/0'/2'/0"});
    * const publicKey = await trezorNode.run();
    * console.log(publicKey);
-   * @returns {string} public key for the BIP32 path of a given instance
+   * @returns {string|Array<string>} public key or keys for the BIP32 paths of a given instance
    */
   async run() {
     const payload = await super.run();


### PR DESCRIPTION
This will enable a user to verify and spend from multiple addresses in a tool such as caravan.

For public key verification, a public key will be returned as a string for a single public key represented by a single BIP32 path maintaining backward compatibility.  For multiple addresses, referring to multiple BIP32 paths, an array of public keys is returned.

An extra named argument `bip32Paths` has been added to the exports which will take an array of BIP32 paths.  It is required to provide either the single `bip32Path` argument or the multiple `bip32Paths` argument.

Trezor provides a separate API call for multiple BIP32 paths.  Ledger's API does not, each public key for each path requires a separate API call, and therefore a confirmation on the device for each key that is exported.  These are done in a loop and stored and returned as an array, similar to how Trezor naturally does it.  The Trezor code loops for message validation looping through all provided BIP32 paths