### PR TITLE
allow unusual paths on trezor

### DIFF
--- a/src/trezor.js
+++ b/src/trezor.js
@@ -16,6 +16,7 @@ import {
   ACTIVE,
   INFO,
   ERROR,
+  WARNING,
 } from "./interaction";
 
 const TrezorConnect = require("trezor-connect").default;
@@ -79,12 +80,12 @@ export class TrezorExportHDNode extends TrezorInteraction {
       const coinPath = bip32PathSegments[2];
       if (this.network === NETWORKS.MAINNET) {
         if (! coinPath.match(/^0'/)) {
-          messages[PENDING].push({level: ERROR, text: "Mainnet BIP32 path must have a second component of 0'", code: "trezor.bip32_path.mismatch"});
+          messages[ACTIVE].push({level: WARNING, text: "On Trezor model T the screen may display a 'Confirm path' warning message.", code: "trezor.bip32_path.mismatch"});
         }
       }
       if (this.network === NETWORKS.TESTNET) {
         if (! coinPath.match(/^1'/)) {
-          messages[PENDING].push({level: ERROR, text: "Testnet BIP32 path must have a second component of 1'", code: "trezor.bip32_path.mismatch"});
+          messages[ACTIVE].push({level: WARNING, text: "On Trezor model T the screen may display a 'Confirm path' warning message.'", code: "trezor.bip32_path.mismatch"});
         }
       }
     }
@@ -107,6 +108,7 @@ export class TrezorExportHDNode extends TrezorInteraction {
     const result = await TrezorConnect.getPublicKey({
       path: this.bip32Path,
       coin: this.trezorCoin,
+      crossChain: true,
     });
     if (!result.success) {
       throw new Error(result.payload.error);

--- a/src/trezor.test.js
+++ b/src/trezor.test.js
@@ -135,15 +135,15 @@ describe("Test trezor lib", () => {
             })
 
             const interactionTestPathMAINNET = new TrezorExportPublicKey({network: NETWORKS.MAINNET, bip32Path: "m/45'/1'/0'/1"});
-            it("should properly report error for a testnet derivation path on mainnet for wallet state pending", () => {
-                const hasError = interactionTestPathMAINNET.hasMessagesFor({walletState:"pending", level: 'error', code: "trezor.bip32_path.mismatch"});
-                expect(hasError).toBe(true);
+            it("should properly report warning for a testnet derivation path on mainnet for wallet state pending", () => {
+                const hasWarning = interactionTestPathMAINNET.hasMessagesFor({walletState:"active", level: 'warning', code: "trezor.bip32_path.mismatch"});
+                expect(hasWarning).toBe(true);
             })
 
             const interactionMainPathTESTNET = new TrezorExportPublicKey({network: NETWORKS.TESTNET, bip32Path: "m/45'/0'/0'/1"});
-            it("should properly report error for a mainnet derivation path on testnet for wallet state pending", () => {
-                const hasError = interactionMainPathTESTNET.hasMessagesFor({walletState:"pending", level: 'error', code: "trezor.bip32_path.mismatch"});
-                expect(hasError).toBe(true);
+            it("should properly report warning for a mainnet derivation path on testnet for wallet state pending", () => {
+                const hasWarning = interactionMainPathTESTNET.hasMessagesFor({walletState:"active", level: 'warning', code: "trezor.bip32_path.mismatch"});
+                expect(hasWarning).toBe(true);
             })
 
             const interactionTestPathTESTNET = new TrezorExportPublicKey({network: NETWORKS.TESTNET, bip32Path: "m/45'/1'/0'/1"});


### PR DESCRIPTION
This will allow the use of trezor with non-standard BIP32 paths.  The same check is performed but it has been downgraded to a warning.  This is a breaking change so versioning will need to be updated accordingly