### PR TITLE
fix(hermit): rename bip32_path to bip32Path during QR code parsing

### DIFF
--- a/src/hermit.js
+++ b/src/hermit.js
@@ -199,7 +199,8 @@ export class HermitExportPublicKey extends HermitReader {
 
   parse(encodedString) {
     const result = parseHermitQRCodeData(encodedString);
-    const {xpub, pubkey, bip32Path} = result;
+    const {xpub, pubkey} = result;
+    const bip32Path = result.bip32_path;
     if (!pubkey) {
       if (xpub) {
         throw new Error("Make sure you export a plain public key and NOT an extended public key.");
@@ -210,6 +211,8 @@ export class HermitExportPublicKey extends HermitReader {
     if (!bip32Path) {
       throw new Error("No BIP32 path in QR code.");
     }
+    result.bip32Path = bip32Path;
+    delete result.bip32_path;
     return result;
   }
 
@@ -246,7 +249,9 @@ export class HermitExportExtendedPublicKey extends HermitReader {
 
   parse(encodedString) {
     const result = parseHermitQRCodeData(encodedString);
-    const {xpub, pubkey, bip32Path} = result;
+    const {xpub, pubkey} = result;
+    const bip32Path = result.bip32_path;
+    
     if (!xpub) {
       if (pubkey) {
         throw new Error("Make sure you export an extended public key and NOT a plain public key.");
@@ -257,6 +262,8 @@ export class HermitExportExtendedPublicKey extends HermitReader {
     if (!bip32Path) {
       throw new Error("No BIP32 path in QR code.");
     }
+    result.bip32Path = bip32Path;
+    delete result.bip32_path;
     return result;
   }
 

--- a/src/hermit.test.js
+++ b/src/hermit.test.js
@@ -76,7 +76,7 @@ describe("HermitExportPublicKey", () => {
       expect(() => { interaction.parse(encodeHermitQRCodeData({})); }).toThrow(/no public key/i);
       expect(() => { interaction.parse(encodeHermitQRCodeData({foo: "bar"})); }).toThrow(/no public key/i);
       expect(() => { interaction.parse(encodeHermitQRCodeData({pubkey: ""})); }).toThrow(/no public key/i);
-      expect(() => { interaction.parse(encodeHermitQRCodeData({bip32Path: "m/45'/0'/0'/0/0"})); }).toThrow(/no public key/i);
+      expect(() => { interaction.parse(encodeHermitQRCodeData({bip32_path: "m/45'/0'/0'/0/0"})); }).toThrow(/no public key/i);
     });
 
     it("throws an error when an extended public key is returned instead", () => {
@@ -85,12 +85,13 @@ describe("HermitExportPublicKey", () => {
 
     it("throws an error when no BIP32 path is returned", () => {
       expect(() => { interaction.parse(encodeHermitQRCodeData({pubkey: "03..."})); }).toThrow(/no bip32 path/i);
-      expect(() => { interaction.parse(encodeHermitQRCodeData({pubkey: "03...", bip32Path: ""})); }).toThrow(/no bip32 path/i);
+      expect(() => { interaction.parse(encodeHermitQRCodeData({pubkey: "03...", bip32_path: ""})); }).toThrow(/no bip32 path/i);
     });
 
     it("returns the result when public key and BIP32 path are present", () => {
+      const data = {pubkey: "03...", bip32_path: "m/45'/0'/0'/0/0"};
       const result = {pubkey: "03...", bip32Path: "m/45'/0'/0'/0/0"};
-      expect(interaction.parse(encodeHermitQRCodeData(result))).toEqual(result);
+      expect(interaction.parse(encodeHermitQRCodeData(data))).toEqual(result);
     });
 
   });
@@ -110,7 +111,7 @@ describe("HermitExportExtendedPublicKey", () => {
       expect(() => { interaction.parse(encodeHermitQRCodeData({})); }).toThrow(/no extended public key/i);
       expect(() => { interaction.parse(encodeHermitQRCodeData({foo: "bar"})); }).toThrow(/no extended public key/i);
       expect(() => { interaction.parse(encodeHermitQRCodeData({xpub: ""})); }).toThrow(/no extended public key/i);
-      expect(() => { interaction.parse(encodeHermitQRCodeData({bip32Path: "m/45'/0'/0'"})); }).toThrow(/no extended public key/i);
+      expect(() => { interaction.parse(encodeHermitQRCodeData({bip32_path: "m/45'/0'/0'"})); }).toThrow(/no extended public key/i);
     });
 
     it("throws an error when a public key is returned instead", () => {
@@ -119,12 +120,13 @@ describe("HermitExportExtendedPublicKey", () => {
 
     it("throws an error when no BIP32 path is returned", () => {
       expect(() => { interaction.parse(encodeHermitQRCodeData({xpub: "xpub..."})); }).toThrow(/no bip32 path/i);
-      expect(() => { interaction.parse(encodeHermitQRCodeData({xpub: "xpub...", bip32Path: ""})); }).toThrow(/no bip32 path/i);
+      expect(() => { interaction.parse(encodeHermitQRCodeData({xpub: "xpub...", bip32_path: ""})); }).toThrow(/no bip32 path/i);
     });
 
     it("returns the result when extended public key and BIP32 path are present", () => {
+      const data = {xpub: "xpub...", bip32_path: "bar"};      
       const result = {xpub: "xpub...", bip32Path: "bar"};
-      expect(interaction.parse(encodeHermitQRCodeData(result))).toEqual(result);
+      expect(interaction.parse(encodeHermitQRCodeData(data))).toEqual(result);
     });
 
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## PR Type

<!---
  What types of change(s) does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bug fix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactor (i.e., no functional changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation changes
* [ ] Other (please describe below):

## Description

Reading Hermit PubKey and XPub QR codes was broken.
Hermit key exporting QR codes have keys `bip32_path` and either `xpub` or `pubkey`. 
The `unchained-wallets` functions were expecting `bip32Path`.
To avoid any breaking changes, I simply renamed the field during the QR code data
parsing and validating.

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No