### PR TITLE
Refactor to update ledger deps to current

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "unchained-wallets",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1205,12 +1205,17 @@
       "integrity": "sha512-m+es6OwqqhHPFGnSZOxGgn7kucWNS6Ep/khCS/avYx/LNz+SRZVRvHT4GuH9Qy6sB9Lg0W7ZEJpKqEzvLGvNoQ=="
     },
     "@ledgerhq/hw-app-btc": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-btc/-/hw-app-btc-5.2.0.tgz",
-      "integrity": "sha512-MG30AgdSHHt9uU0HFE+XTameBRpt8IcmqSz8opeGqAbqwg1PqafpucVQ2nrZW4Qmjd/ZAMh8aKg5HUCyegsOgw==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-btc/-/hw-app-btc-5.17.0.tgz",
+      "integrity": "sha512-npDl6PdbugZKnxPCRXt2wlAzeQ70RcO/vWlSx+pOUW8jAoZgumDhrukURUjTEdqXobpshiKuNjk7JG78x7I43A==",
       "requires": {
-        "@ledgerhq/hw-transport": "^5.2.0",
-        "create-hash": "^1.1.3"
+        "@ledgerhq/hw-transport": "^5.17.0",
+        "@ledgerhq/logs": "^5.17.0",
+        "bip32-path": "^0.4.2",
+        "invariant": "^2.2.4",
+        "ripemd160": "2",
+        "semver": "^7.3.2",
+        "sha.js": "2"
       }
     },
     "@ledgerhq/hw-transport": {
@@ -1251,46 +1256,14 @@
       }
     },
     "@ledgerhq/hw-transport-u2f": {
-      "version": "4.72.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.72.0.tgz",
-      "integrity": "sha512-7Mny6uqXRenSuBdgm3o6DYyTa5UiDTutZhCrq1KgWzwFhaSUWFlExY0A43DRIxvgxwP08nedrIJknlTDV85hhg==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-5.17.0.tgz",
+      "integrity": "sha512-xnyJYZpi5UB+ZBMwlViFAd5A/StojA0OQIYmp+Vcf9ytoU51BaGV4GjAyN6vWsv2ZClGIOK0gTdD/qnUNIqWiQ==",
       "requires": {
-        "@ledgerhq/errors": "^4.72.0",
-        "@ledgerhq/hw-transport": "^4.72.0",
-        "@ledgerhq/logs": "^4.72.0",
+        "@ledgerhq/errors": "^5.17.0",
+        "@ledgerhq/hw-transport": "^5.17.0",
+        "@ledgerhq/logs": "^5.17.0",
         "u2f-api": "0.2.7"
-      },
-      "dependencies": {
-        "@ledgerhq/devices": {
-          "version": "4.78.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-4.78.0.tgz",
-          "integrity": "sha512-tWKS5WM/UU82czihnVjRwz9SXNTQzWjGJ/7+j/xZ70O86nlnGJ1aaFbs5/WTzfrVKpOKgj1ZoZkAswX67i/JTw==",
-          "requires": {
-            "@ledgerhq/errors": "^4.78.0",
-            "@ledgerhq/logs": "^4.72.0",
-            "rxjs": "^6.5.3"
-          }
-        },
-        "@ledgerhq/errors": {
-          "version": "4.78.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-4.78.0.tgz",
-          "integrity": "sha512-FX6zHZeiNtegBvXabK6M5dJ+8OV8kQGGaGtuXDeK/Ss5EmG4Ltxc6Lnhe8hiHpm9pCHtktOsnUVL7IFBdHhYUg=="
-        },
-        "@ledgerhq/hw-transport": {
-          "version": "4.78.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-4.78.0.tgz",
-          "integrity": "sha512-xQu16OMPQjFYLjqCysij+8sXtdWv2YLxPrB6FoLvEWGTlQ7yL1nUBRQyzyQtWIYqZd4THQowQmzm1VjxuN6SZw==",
-          "requires": {
-            "@ledgerhq/devices": "^4.78.0",
-            "@ledgerhq/errors": "^4.78.0",
-            "events": "^3.0.0"
-          }
-        },
-        "@ledgerhq/logs": {
-          "version": "4.72.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-4.72.0.tgz",
-          "integrity": "sha512-o+TYF8vBcyySRsb2kqBDv/KMeme8a2nwWoG+lAWzbDmWfb2/MrVWYCVYDYvjXdSoI/Cujqy1i0gIDrkdxa9chA=="
-        }
       }
     },
     "@ledgerhq/hw-transport-webusb": {
@@ -1918,6 +1891,11 @@
         "typeforce": "^1.11.5",
         "wif": "^2.0.6"
       }
+    },
+    "bip32-path": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/bip32-path/-/bip32-path-0.4.2.tgz",
+      "integrity": "sha1-XbBBataCJxLwd4NuJVe4aXwMfJk="
     },
     "bip66": {
       "version": "1.1.5",
@@ -6976,6 +6954,11 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unchained-wallets",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Unchained Capital's HD Wallets Library",
   "main": "lib/index.js",
   "repository": {
@@ -39,9 +39,9 @@
   "bin": {},
   "dependencies": {
     "@babel/polyfill": "^7.7.0",
-    "@ledgerhq/hw-app-btc": "^5.2.0",
+    "@ledgerhq/hw-app-btc": "^5.17.0",
     "@ledgerhq/hw-transport-node-hid": "^5.17.0",
-    "@ledgerhq/hw-transport-u2f": "^4.72.0",
+    "@ledgerhq/hw-transport-u2f": "^5.17.0",
     "@ledgerhq/hw-transport-webusb": "^5.17.0",
     "bignumber.js": "^8.1.1",
     "bitcoinjs-lib": "^4.0.5",


### PR DESCRIPTION
Due to a recent refactoring of the Ledger code, an old function accessible from the btc object itself is now split out into its own library because it does not require the transport or anything. Import these functions directly and refactor the call to the btc `app`.

Now the latest package versions work.

Ran through the test suite with Ledger and things are working. With U2F fallback (firefox) on MacOS, I get occasional fails to sign. Exit the btc app and re-open it, then try again. In my case, eventually it will sign. This is not a good experience, but it works. The webusb (Chromium) experience is vastly superior.

![Screen Shot 2020-06-29 at 10 43 29 AM](https://user-images.githubusercontent.com/10471648/86038304-910e9700-b9f5-11ea-958e-9f66bfb96a7c.png)
![Screen Shot 2020-06-29 at 10 40 49 AM](https://user-images.githubusercontent.com/10471648/86038306-923fc400-b9f5-11ea-882f-771a44bd494b.png)


