### PR TITLE
Updates object to optionally include amount iff `amountSats` exists

### DIFF
--- a/src/trezor.js
+++ b/src/trezor.js
@@ -826,7 +826,7 @@ function trezorInput(input, bip32Path) {
     prev_hash: input.txid,
     prev_index: input.index,
     address_n: bip32PathToSequence(bip32Path),
-    amount: BigNumber(input.amountSats).toString(),
+    ...(input.amountSats && {amount: BigNumber(input.amountSats).toString()}),
   };
 }
 


### PR DESCRIPTION
It's not a requirement to include the amounts with your inputs as the information is on chain. But if the caller does include it, include it.