### PR TITLE
Set multisig signatures array size to length of pubkeys

### DIFF
--- a/src/trezor.js
+++ b/src/trezor.js
@@ -814,14 +814,15 @@ export function trezorCoin(network) {
 
 function trezorInput(input, bip32Path) {
   const requiredSigners = multisigRequiredSigners(input.multisig);
+  const publicKeys = multisigPublicKeys(input.multisig);
   const addressType = multisigAddressType(input.multisig);
   const spendType = ADDRESS_SCRIPT_TYPES[addressType];
   return {
     script_type: spendType,
     multisig: {
       m: requiredSigners,
-      pubkeys: multisigPublicKeys(input.multisig).map((publicKey) => trezorPublicKey(publicKey)),
-      signatures: Array(requiredSigners).fill(''),
+      pubkeys: publicKeys.map((publicKey) => trezorPublicKey(publicKey)),
+      signatures: Array(publicKeys.length).fill(''),
     },
     prev_hash: input.txid,
     prev_index: input.index,


### PR DESCRIPTION
requiredSigners could be <= pubkeys.length ... but the Trezor firmware seems to want to place signatures at the same index as the pubkey.