### PR TITLE
Remove conditional logic to add SIGHASH_ALL byte

### DIFF
--- a/src/ledger.js
+++ b/src/ledger.js
@@ -30,6 +30,7 @@ import {
   getFingerprintFromPublicKey,
   deriveExtendedPublicKey,
   unsignedMultisigTransaction,
+  signatureNoSighashType,
 } from "unchained-bitcoin";
 
 import {
@@ -882,8 +883,14 @@ export class LedgerSignMultisigTransaction extends LedgerBitcoinInteraction {
           transactionVersion: 1, // tx version
         },
       );
-      return (transactionSignature || []).map(inputSignature => `${inputSignature}01`);
+      return this.parse(transactionSignature);
     });
+  }
+
+  parse(transactionSignature) {
+    // Ledger signatures include the SIGHASH byte (0x01) if signing for P2SH-P2WSH or P2WSH ...
+    // but NOT for P2SH ... This function should always return the signature with SIGHASH byte appended.
+    return (transactionSignature || []).map(inputSignature => `${signatureNoSighashType(inputSignature)}01`);
   }
 
   ledgerInputs() {

--- a/src/ledger.js
+++ b/src/ledger.js
@@ -882,7 +882,7 @@ export class LedgerSignMultisigTransaction extends LedgerBitcoinInteraction {
           transactionVersion: 1, // tx version
         },
       );
-      return (transactionSignature || []).map((inputSignature) => (inputSignature.endsWith('01') ? inputSignature : `${inputSignature}01`));
+      return (transactionSignature || []).map(inputSignature => `${inputSignature}01`);
     });
   }
 

--- a/src/ledger.test.js
+++ b/src/ledger.test.js
@@ -218,6 +218,20 @@ describe('ledger', () => {
           });
         }
 
+        it("checks signatures include proper SIGHASH byte", () => {
+          // Signature format:
+          //   first byte signifies DER encoding           (0x30)
+          //   second byte is length of signature in bytes (0x03)
+          // The string length is however long the signature is minus these two starting bytes
+          // plain signature without SIGHASH (foobar is 3 bytes, string length = 6, which is 3 bytes)
+          expect(interactionBuilder().parse(["3003foobar"])).toEqual(["3003foobar01"]);
+          // signature actually ends in 0x01 (foob01 is 3 bytes, string length = 6, which is 3 bytes)
+          expect(interactionBuilder().parse(["3003foob01"])).toEqual(["3003foob0101"]);
+          // signature with sighash already included (foobar is 3 bytes, string length = 8, which is 4 bytes) ...
+          // we expect this to chop off the 01 and add it back
+          expect(interactionBuilder().parse(["3003foobar01"])).toEqual(["3003foobar01"]);
+        });
+
       });
     });
 

--- a/src/trezor.js
+++ b/src/trezor.js
@@ -36,6 +36,7 @@ import {
   P2SH,
   P2SH_P2WSH,
   P2WSH,
+  signatureNoSighashType,
 } from "unchained-bitcoin";
 
 import {
@@ -683,7 +684,10 @@ export class TrezorSignMultisigTransaction extends TrezorInteraction {
    * @returns {string[]} array of input signatures, one per input
    */
   parse(payload) {
-    return (payload.signatures || []).map((inputSignature) => (`${inputSignature}01`));
+    // While we don't anticipate Trezor making firmware changes to include SIGHASH bytes with signatures,
+    // let's go ahead and make sure that we're not double adding the SIGHASH byte in case they do in the future.
+
+    return (payload.signatures || []).map((inputSignature) => (`${signatureNoSighashType(inputSignature)}01`));
   }
 
 }


### PR DESCRIPTION
If the signature ends in `0x01` and the downstream application is expecting a SIGHASH_ALL byte to be included, then this conditional will invalidate the signature.

Make this API always return the signature with the SIGHASH byte included.