### PR TITLE
Adds optional `includeXFP` when exporting xpubs / public keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ import {HERMIT, HermitExportPublicKey, HermitExportExtendedPublicKey, HermitSign
  */
 export const VERSION = version;
 
+export const MULTISIG_ROOT = "m/45'";
+
 /**
  * Enumeration of keystores which support direct interactions.
  *
@@ -92,6 +94,7 @@ export function GetMetadata({keystore}) {
  * @param {KEYSTORES} options.keystore - keystore to use
  * @param {string} options.network - bitcoin network
  * @param {string} options.bip32Path - the BIP32 path of the HD node of the public key
+ * @param {string} options.includeXFP - also return root fingerprint
  * @return {module:interaction.KeystoreInteraction} keystore-specific interaction instance
  * @example
  * import {MAINNET} from "unchained-bitcoin";
@@ -100,15 +103,24 @@ export function GetMetadata({keystore}) {
  * const interaction = ExportPublicKey({keystore: TREZOR, network: MAINNET, bip32Path: "m/45'/0'/0'/0/0"});
  * const publicKey = await interaction.run();
  */
-export function ExportPublicKey({keystore, network, bip32Path}) {
+export function ExportPublicKey({
+                                  keystore,
+                                  network,
+                                  bip32Path,
+                                  includeXFP,
+                                }) {
   switch (keystore) {
     case TREZOR:
       return new TrezorExportPublicKey({
         network,
         bip32Path,
+        includeXFP,
       });
     case LEDGER:
-      return new LedgerExportPublicKey({bip32Path});
+      return new LedgerExportPublicKey({
+        bip32Path,
+        includeXFP,
+      });
     case HERMIT:
       return new HermitExportPublicKey({bip32Path});
     default:
@@ -130,6 +142,7 @@ export function ExportPublicKey({keystore, network, bip32Path}) {
  * @param {KEYSTORES} options.keystore - keystore to use
  * @param {string} options.network - bitcoin network
  * @param {string} options.bip32Path - the BIP32 path of the HD node of the extended public key
+ * @param {string} options.includeXFP - also return root fingerprint
  * @return {module:interaction.KeystoreInteraction} keystore-specific interaction instance
  * @example
  * import {MAINNET} from "unchained-bitcoin";
@@ -138,12 +151,18 @@ export function ExportPublicKey({keystore, network, bip32Path}) {
  * const interaction = ExportExtendedPublicKey({keystore: TREZOR, network: MAINNET, bip32Path: "m/45'/0'/0'/0/0"});
  * const xpub = await interaction.run();
  */
-export function ExportExtendedPublicKey({keystore, network, bip32Path}) {
+export function ExportExtendedPublicKey({
+                                          keystore,
+                                          network,
+                                          bip32Path,
+                                          includeXFP,
+                                        }) {
   switch (keystore) {
     case TREZOR:
       return new TrezorExportExtendedPublicKey({
         network,
         bip32Path,
+        includeXFP,
       });
     case HERMIT:
       return new HermitExportExtendedPublicKey({bip32Path});
@@ -151,6 +170,7 @@ export function ExportExtendedPublicKey({keystore, network, bip32Path}) {
       return new LedgerExportExtendedPublicKey({
         network,
         bip32Path,
+        includeXFP,
       });
     default:
       return new UnsupportedInteraction({

--- a/src/ledger.js
+++ b/src/ledger.js
@@ -561,6 +561,34 @@ class LedgerExportHDNode extends LedgerBitcoinInteraction {
   }
 
   /**
+   * Get fingerprint from parent pubkey. This is useful for generating xpubs
+   * which need the fingerprint of the parent pubkey
+   *
+   * Optionally get root fingerprint for device. This is useful for keychecks and necessary
+   * for PSBTs
+   *
+   * @param {boolean} root fingerprint or not
+   * @returns {string} fingerprint
+   */
+  async getFingerprint(root = false) {
+    const pubkey = root ? await this.getMultisigRootPublicKey() : await this.getParentPublicKey();
+    return getFingerprintFromPublicKey(pubkey);
+  }
+
+  getParentPublicKey() {
+    return this.withApp(async (app) => {
+      const parentPath = getParentPath(this.bip32Path);
+      return (await app.getWalletPublicKey(parentPath)).publicKey;
+    });
+  }
+
+  getMultisigRootPublicKey() {
+    return this.withApp(async (app) => {
+      return (await app.getWalletPublicKey()).publicKey; // Call getWalletPublicKey w no path to get BIP32_ROOT (m)
+    });
+  }
+
+  /**
    * See {@link https://github.com/LedgerHQ/ledgerjs/tree/master/packages/hw-app-btc#getwalletpublickey}.
    *
    * @returns {object} the HD node object.
@@ -586,14 +614,33 @@ class LedgerExportHDNode extends LedgerBitcoinInteraction {
 export class LedgerExportPublicKey extends LedgerExportHDNode {
 
   /**
+   * @param {string} bip32Path - the BIP32 path for the HD node
+   * @param {boolean} includeXFP - return xpub with root fingerprint concatenated
+   */
+  constructor({bip32Path, includeXFP = false}) {
+    super({bip32Path});
+    this.includeXFP = includeXFP;
+  }
+
+  /**
    * Parses out and compresses the public key from the response of
    * `LedgerExportHDNode`.
    *
-   * @returns {string} -- (compressed) public key in hex
+   * @returns {string|Object} (compressed) public key in hex (returns object if asked to include root fingerprint)
    */
   async run() {
     const result = await super.run();
-    return this.parsePublicKey((result || {}).publicKey);
+    const publicKey = this.parsePublicKey((result || {}).publicKey);
+    if (this.includeXFP) {
+      let rootFingerprint = await this.getFingerprint(true);
+      rootFingerprint = rootFingerprint.toString(16);
+      return {
+        rootFingerprint,
+        publicKey,
+      };
+    }
+
+    return publicKey;
   }
 
   /**
@@ -622,30 +669,20 @@ export class LedgerExportPublicKey extends LedgerExportHDNode {
  * @extends {module:ledger.LedgerExportHDNode}
  */
 export class LedgerExportExtendedPublicKey extends LedgerExportHDNode {
-  constructor({bip32Path, network}) {
+
+  /**
+   * @param {string} bip32Path path
+   * @param {string} network bitcoin network
+   * @param {boolean} includeXFP - return xpub with root fingerprint concatenated
+   */
+  constructor({bip32Path, network, includeXFP}) {
     super({bip32Path});
     this.network = network;
+    this.includeXFP = includeXFP;
   }
 
   messages() {
     return super.messages();
-  }
-
-  /**
-   * Get fingerprint from parent pubkey. This is useful for generating xpubs
-   * which need the fingerprint of the parent pubkey
-   * @returns {string} fingerprint
-   */
-  async getFingerprint() {
-    const pubkey = await this.getParentPublicKey();
-    return getFingerprintFromPublicKey(pubkey);
-  }
-
-  getParentPublicKey() {
-    return this.withApp(async (app) => {
-      const parentPath = getParentPath(this.bip32Path);
-      return (await app.getWalletPublicKey(parentPath)).publicKey;
-    });
   }
 
   /**
@@ -655,18 +692,30 @@ export class LedgerExportExtendedPublicKey extends LedgerExportHDNode {
    * const interaction = new LedgerExportExtendedPublicKey({network, bip32Path});
    * const xpub = await interaction.run();
    * console.log(xpub);
-   * @returns {string} extended public key(xpub) for the BIP32 path of a given instance
+   *
+   * @returns {string|Object} the extended public key (returns object if asked to include root fingerprint)
    */
   async run() {
     const walletPublicKey = await super.run();
     const fingerprint = await this.getFingerprint();
-    return deriveExtendedPublicKey(
+
+    const xpub = deriveExtendedPublicKey(
       this.bip32Path,
       walletPublicKey.publicKey,
       walletPublicKey.chainCode,
       fingerprint,
       this.network,
     );
+
+    if (this.includeXFP) {
+      let rootFingerprint = await this.getFingerprint(true);
+      rootFingerprint = rootFingerprint.toString(16);
+      return {
+        rootFingerprint,
+        xpub,
+      };
+    }
+    return xpub;
   }
 }
 


### PR DESCRIPTION
This PR adds an opt-in, completely optional way to interact with the Ledger and Trezor keystores in the event you would like them to return the root fingerprint of the device in addition to the `keyMaterial` (xpub or pubkey).

The old functionality remains untouched.

In the future, we will make a breaking change to these key export classes where the returned value is an Object instead of a string. But for now - we can still support both.