### PR TITLE
Improve ConfirmMultisigAddress with optional publicKey parameter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -278,6 +278,8 @@ export function SignMultisigTransaction({keystore, network, inputs, outputs, bip
  * `bip32Path` is the BIP32 path for the publiic key in the address on
  * this device.
  *
+ * `publicKey` optional, is the public key expected to be at `bip32Path`.
+ *
  * **Supported keystores:** Trezor
  *
  * @param {Object} options - options argument
@@ -285,12 +287,17 @@ export function SignMultisigTransaction({keystore, network, inputs, outputs, bip
  * @param {string} options.network - bitcoin network
  * @param {object} options.multisig - `Multisig` object representing the address
  * @param {string} options.bip32Path - the BIP32 path on this device containing a public key from the address
+ * @param {string} options.publicKey - optional, the public key expected to be at the given BIP32 path
  * @return {module:interaction.KeystoreInteraction} keystore-specific interaction instance
  * @example
  * import {
  *   generateMultisigFromHex, TESTNET, P2SH,
  * } from "unchained-bitcoin";
- * import {ConfirmMultisigAddress, TREZOR} from "unchained-wallets";
+ * import {
+ *   ConfirmMultisigAddress,
+ *   multisigPublicKeys,
+ *   trezorPublicKey,
+ *   TREZOR} from "unchained-wallets";
  * const redeemScript = "5...ae";
  * const multisig = generateMultisigFromHex(TESTNET, P2SH, redeemScript);
  * const interaction = ConfirmMultisigAddress({
@@ -300,6 +307,20 @@ export function SignMultisigTransaction({keystore, network, inputs, outputs, bip
  *   bip32Path: "m/45'/1'/0'/0/0",
  * });
  * await interaction.run();
+ *
+ * With publicKey:
+ * const redeemScript = "5...ae";
+ * const multisig = generateMultisigFromHex(TESTNET, P2SH, redeemScript);
+ * const publicKey = trezorPublicKey(multisigPublicKeys(this.multisig)[2])
+ * const interaction = ConfirmMultisigAddress({
+ *   keystore: TREZOR,
+ *   publicKey,
+ *   network: TESTNET,
+ *   multisig,
+ *   bip32Path: "m/45'/1'/0'/0/0",
+ * });
+ * await interaction.run();
+ *
  *
  */
 export function ConfirmMultisigAddress({keystore, network, bip32Path, multisig, publicKey}) {

--- a/src/index.js
+++ b/src/index.js
@@ -302,13 +302,14 @@ export function SignMultisigTransaction({keystore, network, inputs, outputs, bip
  * await interaction.run();
  *
  */
-export function ConfirmMultisigAddress({keystore, network, bip32Path, multisig}) {
+export function ConfirmMultisigAddress({keystore, network, bip32Path, multisig, publicKey}) {
   switch (keystore) {
     case TREZOR:
       return new TrezorConfirmMultisigAddress({
         network,
         bip32Path,
         multisig,
+        publicKey,
       });
     default:
       return new UnsupportedInteraction({

--- a/src/trezor.js
+++ b/src/trezor.js
@@ -37,7 +37,9 @@ import {
   P2SH_P2WSH,
   P2WSH,
   signatureNoSighashType,
+  networkData,
 } from "unchained-bitcoin";
+import bitcoin from "bitcoinjs-lib";
 
 import {
   DirectKeystoreInteraction,
@@ -793,11 +795,13 @@ export class TrezorConfirmMultisigAddress extends TrezorInteraction {
    * @param {string} options.network - bitcoin network
    * @param {string} options.bip32Path - BIP32 path to the public key on this device used in the multisig address
    * @param {Multisig} options.multisig - multisig object
+   * @param {string} options.publicKey - optional public key to confirm
    */
-  constructor({network, bip32Path, multisig}) {
+  constructor({network, bip32Path, multisig, publicKey}) {
     super({network});
     this.bip32Path = bip32Path;
     this.multisig = multisig;
+    this.publicKey = publicKey;
   }
 
   /**
@@ -809,18 +813,27 @@ export class TrezorConfirmMultisigAddress extends TrezorInteraction {
   messages() {
     const messages = super.messages();
 
-    messages.push({
-      state: ACTIVE,
-      level: INFO,
-      text: `Confirm in the Trezor Connect window that you want to 'Export ${this.trezorCoin} address'.  You may be prompted to enter your PIN.`,
-      code: "trezor.connect.confirm_address",
-    });
+    if (this.publicKey) {
+      messages.push({
+        state: ACTIVE,
+        level: INFO,
+        text:`Confirm in the Trezor Connect window that you want to ‘Export multiple ${this.trezorCoin} addresses’. You may be prompted to enter your PIN. You may also receive a warning about your selected BIP32 path.`,
+        code: "trezor.connect.confirm_address",
+      });
+    } else {
+      messages.push({
+        state: ACTIVE,
+        level: INFO,
+        text: `Confirm in the Trezor Connect window that you want to 'Export ${this.trezorCoin} address'.  You may be prompted to enter your PIN.`,
+        code: "trezor.connect.confirm_address",
+      });
+    }
 
     messages.push({
       state: ACTIVE,
       level: INFO,
       version: "One",
-      text: "Confirm the addresss on your Trezor device.",
+      text: "It is safe to continue and confirm the address on your Trezor device.",
       messages: [
         // FIXME this only shows up on P2SH?
         {
@@ -864,23 +877,67 @@ export class TrezorConfirmMultisigAddress extends TrezorInteraction {
    * @returns {Array<function, Object>} TrezorConnect parameters
    */
   connectParams() {
-    return [
-      TrezorConnect.getAddress,
-      {
-        path: this.bip32Path,
-        address: multisigAddress(this.multisig),
-        showOnTrezor: true,
-        coin: this.trezorCoin,
-        crossChain: true,
-        multisig: {
-          m: multisigRequiredSigners(this.multisig),
-          pubkeys: multisigPublicKeys(this.multisig).map((publicKey) => trezorPublicKey(publicKey)),
+    if (this.publicKey) {
+      return [
+        TrezorConnect.getAddress,
+        {
+          bundle: [
+            {
+              path: this.bip32Path,
+              showOnTrezor: false,
+              coin: this.trezorCoin,
+              crossChain: true,
+            },
+            {
+              path: this.bip32Path,
+              address: multisigAddress(this.multisig),
+              showOnTrezor: true,
+              coin: this.trezorCoin,
+              crossChain: true,
+              multisig: {
+                m: multisigRequiredSigners(this.multisig),
+                pubkeys: multisigPublicKeys(this.multisig).map((publicKey) => trezorPublicKey(publicKey)),
+              },
+              scriptType: ADDRESS_SCRIPT_TYPES[multisigAddressType(this.multisig)],
+            },
+          ],
+        }
+      ];
+    } else {
+      return [
+        TrezorConnect.getAddress,
+        {
+          path: this.bip32Path,
+          address: multisigAddress(this.multisig),
+          showOnTrezor: true,
+          coin: this.trezorCoin,
+          crossChain: true,
+          multisig: {
+            m: multisigRequiredSigners(this.multisig),
+            pubkeys: multisigPublicKeys(this.multisig).map((publicKey) => trezorPublicKey(publicKey)),
+          },
+          scriptType: ADDRESS_SCRIPT_TYPES[multisigAddressType(this.multisig)],
         },
-        scriptType: ADDRESS_SCRIPT_TYPES[multisigAddressType(this.multisig)],
-      },
-    ];
+      ]
+    }
   }
 
+  parse(payload) {
+    if (!this.publicKey) {
+      return payload;
+    }
+    const keyPair = bitcoin.ECPair.fromPublicKey(
+      Buffer.from(this.publicKey, 'hex'))
+    const { address } = bitcoin.payments.p2pkh({
+      pubkey: keyPair.publicKey,
+      network: networkData(this.network),
+    })
+    if (address !== payload[0].address && address != payload[1].address) {
+      throw new Error("Wrong public key specified");
+    }
+    return payload;
+  }
+  
 }
 
 /**

--- a/src/trezor.js
+++ b/src/trezor.js
@@ -774,6 +774,12 @@ export class TrezorSignMultisigTransaction extends TrezorInteraction {
 /**
  * Shows a multisig address on the device and prompts the user to
  * confirm it.
+ * If the optional publicKey parameter is used, the public key at 
+ * the given BIP32 path is checked, returning an error if they don't match.
+ *
+ * Without the publicKey parameter, this function simply checks that the 
+ * public key at the given BIP32 path is in the redeemscript (with
+ * validation on-device.
  *
  * @extends {module:trezor.TrezorInteraction}
  * @example
@@ -918,7 +924,7 @@ export class TrezorConfirmMultisigAddress extends TrezorInteraction {
           },
           scriptType: ADDRESS_SCRIPT_TYPES[multisigAddressType(this.multisig)],
         },
-      ]
+      ];
     }
   }
 
@@ -927,11 +933,11 @@ export class TrezorConfirmMultisigAddress extends TrezorInteraction {
       return payload;
     }
     const keyPair = bitcoin.ECPair.fromPublicKey(
-      Buffer.from(this.publicKey, 'hex'))
+      Buffer.from(this.publicKey, 'hex'));
     const { address } = bitcoin.payments.p2pkh({
       pubkey: keyPair.publicKey,
       network: networkData(this.network),
-    })
+    });
     if (address !== payload[0].address && address != payload[1].address) {
       throw new Error("Wrong public key specified");
     }

--- a/src/trezor.test.js
+++ b/src/trezor.test.js
@@ -267,17 +267,17 @@ describe('trezor', () => {
   });
 
   describe("TrezorConfirmMultisigAddress", () => {
+    let TMP_FIXTURES = JSON.parse(JSON.stringify(TEST_FIXTURES));
 
-    TEST_FIXTURES.multisigs.forEach((fixture) => {
-
+    TMP_FIXTURES.multisigs.forEach((fixture) => {
+      Reflect.deleteProperty(fixture, 'publicKey');
       describe(`displaying a ${fixture.description}`, () => {
-
         function interactionBuilder() { return new TrezorConfirmMultisigAddress(fixture); }
 
         itHasStandardMessages(interactionBuilder);
         itThrowsAnErrorOnAnUnsuccessfulRequest(interactionBuilder);
 
-        it("uses TrezorConnect.getAddress", () => {
+        it("uses TrezorConnect.getAddress without a public key", () => {
           const interaction = interactionBuilder();
           const [method, params] = interaction.connectParams();
           expect(method).toEqual(TrezorConnect.getAddress);
@@ -294,6 +294,35 @@ describe('trezor', () => {
     });
   });
 
+  describe("TrezorConfirmMultisigAddress", () => {
+
+    TEST_FIXTURES.multisigs.forEach((fixture) => {
+
+      describe(`displaying a ${fixture.description}`, () => {
+
+        function interactionBuilder() { return new TrezorConfirmMultisigAddress(fixture); }
+
+        itHasStandardMessages(interactionBuilder);
+        itThrowsAnErrorOnAnUnsuccessfulRequest(interactionBuilder);
+
+        it("uses TrezorConnect.getAddress with a public key", () => {
+          const interaction = interactionBuilder();
+          const [method, params] = interaction.connectParams();
+          expect(method).toEqual(TrezorConnect.getAddress);
+          expect(params.bundle[0].path).toEqual(fixture.bip32Path);
+          expect(params.bundle[0].showOnTrezor).toBe(false);
+          expect(params.bundle[0].coin).toEqual(trezorCoin(fixture.network));
+          expect(params.bundle[0].crossChain).toBe(true);          
+          expect(params.bundle[1].path).toEqual(fixture.bip32Path);
+          expect(params.bundle[1].address).toEqual(fixture.address);
+          expect(params.bundle[1].showOnTrezor).toBe(true);
+          expect(params.bundle[1].coin).toEqual(trezorCoin(fixture.network));
+          expect(params.bundle[1].crossChain).toBe(true);
+          // FIXME check multisig details
+        });
+      });
+    });
+  });
 });
 
 


### PR DESCRIPTION
# Summary
When calling `ConfirmMultisigAddress` the user should expect this behavior:
For Device A which is in control of Public Key A at BIP32Path A:
1. The multisig address should be shown on the Device A.
2. BIP32Path A of the Public Key A is shown on Device A.
3. If Public Key A isn't in the redeem script of the multisig address, an error is thrown.
4. If the key on Device A at BIP32Path A isn't Public Key A, an error is thrown.

Before this PR, only 1-3 was true. This PR adds 4 via an optional parameter, for backwards compatibility.

## Details
`ConfirmMultisigAddress` currently only works on Trezor.  
The trezor interaction uses [getAddress](https://github.com/trezor/connect/blob/v8/docs/methods/getAddress.md#exporting-single-address). The important parameters passed to `getAddress` are: `path`, `address` and `multisig`, which allows you to verify that the key at on the device at `path` is used in `address`.

The problem arises when you use two public keys from two devices at the same BIP32 path. In this scenario, the inputs to `getAddress` are the same, so the devices are interchangeable. This means you can't specify which specific device you are checking, just whether or not the device is in control of **a key**, not a **specific key**.

A better solution is for Trezor to have either a public key, key index (which key in the multisig redeemscript), or a device fingerprint parameter.

This PR works around that by getting *two* address in the `getAddress` call via the `bundle` optional parameter. If an optional `publicKey` parameter is passed, the *singlesig* address at the same bip32 path is retrieved (without showing on device). The singlesig address is compared to the `publicKey`, if they don't agree, an error is thrown.

A benefit of this approach is the the Trezor T will display the bip32 path (as long as it isn't a standard *singlesig* path), which it wouldn't otherwise. A downside to this approach is that the user confirms the address on the device but an error is still returned, which could cause some confusion.
