### PR TITLE
XFP should be 8-char hex

### DIFF
--- a/src/ledger.js
+++ b/src/ledger.js
@@ -633,7 +633,8 @@ export class LedgerExportPublicKey extends LedgerExportHDNode {
     const publicKey = this.parsePublicKey((result || {}).publicKey);
     if (this.includeXFP) {
       let rootFingerprint = await this.getFingerprint(true);
-      rootFingerprint = rootFingerprint.toString(16);
+      // zero pad the xfp.
+      rootFingerprint = (rootFingerprint + 0x100000000).toString(16).substr(-8);
       return {
         rootFingerprint,
         publicKey,

--- a/src/trezor.js
+++ b/src/trezor.js
@@ -488,7 +488,9 @@ export class TrezorExportHDNode extends TrezorInteraction {
     for (let i = 0; i < payload.length; i++) {
       // Find the payload with bip32 = MULTISIG_ROOT to get xfp
       if (payload[i].serializedPath === MULTISIG_ROOT) {
-        rootFingerprint = payload[i].fingerprint.toString(16);
+        let fp = payload[i].fingerprint;
+        // zero pad the hex string
+        rootFingerprint = (fp + 0x100000000).toString(16).substr(-8);
       } else {
         keyMaterial = pubkey ? payload[i].publicKey : payload[i].xpub;
       }


### PR DESCRIPTION
The XFP is converted from an int to a hex string, but wasn't being zero-padded to 8 characters, so there was a 1-in-16 chance of a 7 character XFP, and a 1-in-256 chance of a 6-digit XFP.

This PR adds the necessary zero-padding.