### PR TITLE
Quickfix: update coldcard wallet config output to include bip32paths

### DIFF
--- a/src/coldcard.fixtures.js
+++ b/src/coldcard.fixtures.js
@@ -1,77 +1,97 @@
-import {COLDCARD_WALLET_CONFIG_VERSION} from './coldcard';
+import { COLDCARD_WALLET_CONFIG_VERSION } from "./coldcard";
 
-import {ROOT_FINGERPRINT} from "unchained-bitcoin";
+import { ROOT_FINGERPRINT } from "unchained-bitcoin";
 
 export const coldcardFixtures = {
   // These use the Open Source Wallet words from the Caravan Test Suite
   validColdcardXpubJSON: {
     p2sh_deriv: "m/45'",
-    p2sh: "tpubDA4nUAdTmYwqJEETnxhH5HyN817oXugoa63GmThiDVNDKGf4uaG6QAk9BUo7RdXv1LFF7yBognGFPWzdwXY4XWMHyJ5mtZaVFEU5MtMfj7H",
+    p2sh:
+      "tpubDA4nUAdTmYwqJEETnxhH5HyN817oXugoa63GmThiDVNDKGf4uaG6QAk9BUo7RdXv1LFF7yBognGFPWzdwXY4XWMHyJ5mtZaVFEU5MtMfj7H",
     p2wsh_p2sh_deriv: "m/48'/1'/0'/1'",
-    p2wsh_p2sh: "Upub5THcsrK1mzKPEWiosEaR5Ra5sSLTfgfc2RBqxDWZt9jFrANXFzeKSpjxn7StBgBhBe1YPiZXurj7XrQhggqYV63ZzpWUp27gWiL2wDoVwaW",
+    p2wsh_p2sh:
+      "Upub5THcsrK1mzKPEWiosEaR5Ra5sSLTfgfc2RBqxDWZt9jFrANXFzeKSpjxn7StBgBhBe1YPiZXurj7XrQhggqYV63ZzpWUp27gWiL2wDoVwaW",
     p2wsh_deriv: "m/48'/1'/0'/2'",
-    p2wsh: "Vpub5n7tBWyvvfrs8rgaiWz4sJb6X1KrQGwj3VAD9MzDLRg419Pee4DVGzCzkdxB2U5tQor3bjDia2hU9VSamFF8714rJJb7TzyeSKtZ5PQ1MRN",
+    p2wsh:
+      "Vpub5n7tBWyvvfrs8rgaiWz4sJb6X1KrQGwj3VAD9MzDLRg419Pee4DVGzCzkdxB2U5tQor3bjDia2hU9VSamFF8714rJJb7TzyeSKtZ5PQ1MRN",
     xfp: "F57EC65D",
   },
   validColdcardXpubMainnetJSON: {
     p2sh_deriv: "m/45'",
-    p2sh: "xpub69h9wvon4GzP2S3cLmiBsNdznt29YXBk2TSyQueZsacKZyzMqMR1Fj5JwSiKu8agDRiLWPfw9gSChLW2Yfgpe4tzuhLUD2vFfGsfbtTA3r7",
+    p2sh:
+      "xpub69h9wvon4GzP2S3cLmiBsNdznt29YXBk2TSyQueZsacKZyzMqMR1Fj5JwSiKu8agDRiLWPfw9gSChLW2Yfgpe4tzuhLUD2vFfGsfbtTA3r7",
     p2wsh_p2sh_deriv: "m/48'/0'/0'/1'",
-    p2wsh_p2sh: "Ypub6jGfy3TmqjoeWQhS5wBPw4xZeFubMPzPhZZVBn72J2G6xD6Z1GkbR3be51yknKt4ahighwfwSMAgX9QFUWTxy7pKhzTaLY37EPxBEctgBCs",
+    p2wsh_p2sh:
+      "Ypub6jGfy3TmqjoeWQhS5wBPw4xZeFubMPzPhZZVBn72J2G6xD6Z1GkbR3be51yknKt4ahighwfwSMAgX9QFUWTxy7pKhzTaLY37EPxBEctgBCs",
     p2wsh_deriv: "m/48'/0'/0'/2'",
-    p2wsh: "Zpub746wGi8gzRM8Qjb7dLXmKrW9KDTP4FmGTMJ3DWc5PwvNcGyq3tBhnsXjcDAL5jXoRHMULRmB5CGb42Q8adsoKRbEh2qw1MT56vRxEG4QTvd",
-    xfp: "F57EC65D"
+    p2wsh:
+      "Zpub746wGi8gzRM8Qjb7dLXmKrW9KDTP4FmGTMJ3DWc5PwvNcGyq3tBhnsXjcDAL5jXoRHMULRmB5CGb42Q8adsoKRbEh2qw1MT56vRxEG4QTvd",
+    xfp: "F57EC65D",
   },
   validColdcardXpubNewFirmwareJSON: {
     p2sh_deriv: "m/45'",
-    p2sh: "tpubDA4nUAdTmYwqJEETnxhH5HyN817oXugoa63GmThiDVNDKGf4uaG6QAk9BUo7RdXv1LFF7yBognGFPWzdwXY4XWMHyJ5mtZaVFEU5MtMfj7H",
+    p2sh:
+      "tpubDA4nUAdTmYwqJEETnxhH5HyN817oXugoa63GmThiDVNDKGf4uaG6QAk9BUo7RdXv1LFF7yBognGFPWzdwXY4XWMHyJ5mtZaVFEU5MtMfj7H",
     p2sh_p2wsh_deriv: "m/48'/1'/0'/1'",
-    p2sh_p2wsh: "Upub5THcsrK1mzKPEWiosEaR5Ra5sSLTfgfc2RBqxDWZt9jFrANXFzeKSpjxn7StBgBhBe1YPiZXurj7XrQhggqYV63ZzpWUp27gWiL2wDoVwaW",
+    p2sh_p2wsh:
+      "Upub5THcsrK1mzKPEWiosEaR5Ra5sSLTfgfc2RBqxDWZt9jFrANXFzeKSpjxn7StBgBhBe1YPiZXurj7XrQhggqYV63ZzpWUp27gWiL2wDoVwaW",
     p2wsh_deriv: "m/48'/1'/0'/2'",
-    p2wsh: "Vpub5n7tBWyvvfrs8rgaiWz4sJb6X1KrQGwj3VAD9MzDLRg419Pee4DVGzCzkdxB2U5tQor3bjDia2hU9VSamFF8714rJJb7TzyeSKtZ5PQ1MRN",
+    p2wsh:
+      "Vpub5n7tBWyvvfrs8rgaiWz4sJb6X1KrQGwj3VAD9MzDLRg419Pee4DVGzCzkdxB2U5tQor3bjDia2hU9VSamFF8714rJJb7TzyeSKtZ5PQ1MRN",
     xfp: "F57EC65D",
   },
   invalidColdcardXpubJSON: {
     p2sh_deriv: "m/45'",
     p2wsh_p2sh_deriv: "m/48'/1'/0'/1'",
-    p2wsh_p2sh: "Upub5T4XUooQzDXL58NCHk8ZCw9BsRSLCtnyHeZEExAq1XdnBFXiXVrHFuvvmh3TnCR7XmKHxkwqdACv68z7QKT1vwru9L1SZSsw8B2fuBvtSa6",
+    p2wsh_p2sh:
+      "Upub5T4XUooQzDXL58NCHk8ZCw9BsRSLCtnyHeZEExAq1XdnBFXiXVrHFuvvmh3TnCR7XmKHxkwqdACv68z7QKT1vwru9L1SZSsw8B2fuBvtSa6",
     p2wsh_deriv: "m/48'/1'/0'/2'",
-    p2wsh: "Vpub5mtnnUUL8u4oyRf5d2NZJqDypgmpx8FontedpqxNyjXTi6fLp8fmpp2wedS6UyuNpDgLDoVH23c6rYpFSEfB9jhdbD8gek2stjxhwJeE1Eq",
+    p2wsh:
+      "Vpub5mtnnUUL8u4oyRf5d2NZJqDypgmpx8FontedpqxNyjXTi6fLp8fmpp2wedS6UyuNpDgLDoVH23c6rYpFSEfB9jhdbD8gek2stjxhwJeE1Eq",
     xfp: "0F056943",
   },
 
   testJSONOutput: {
-    xpub: 'tpubD8NXmKsmWp3a3DXhbihAYbYLGaRNVdTnr6JoSxxfXYQcmwVtW2hv8QoDwng6JtEonmJoL3cNEwfd2cLXMpGezwZ2vL2dQ7259bueNKj9C8n',
+    xpub:
+      "tpubD8NXmKsmWp3a3DXhbihAYbYLGaRNVdTnr6JoSxxfXYQcmwVtW2hv8QoDwng6JtEonmJoL3cNEwfd2cLXMpGezwZ2vL2dQ7259bueNKj9C8n",
     rootFingerprint: ROOT_FINGERPRINT,
   },
   testPubkeyOutput: {
-    publicKey: '026942d670b9a5afc8b9b6118374aa7245a1a95b30cadb60069f5d0076aaff2bf5',
+    publicKey:
+      "026942d670b9a5afc8b9b6118374aa7245a1a95b30cadb60069f5d0076aaff2bf5",
     rootFingerprint: ROOT_FINGERPRINT,
     bip32Path: "m/45'",
   },
   testP2wshP2shPubkeyOutput: {
-    publicKey: '0200688aa1961c57819edc321771ef5326c32d752080479bb3e3ed0517302a1cef',
+    publicKey:
+      "0200688aa1961c57819edc321771ef5326c32d752080479bb3e3ed0517302a1cef",
     rootFingerprint: ROOT_FINGERPRINT,
     bip32Path: "m/48'/1'/0'/1'",
   },
   testXpubOutput: {
-    xpub: 'tpubD8NXmKsmWp3a3DXhbihAYbYLGaRNVdTnr6JoSxxfXYQcmwVtW2hv8QoDwng6JtEonmJoL3cNEwfd2cLXMpGezwZ2vL2dQ7259bueNKj9C8n',
+    xpub:
+      "tpubD8NXmKsmWp3a3DXhbihAYbYLGaRNVdTnr6JoSxxfXYQcmwVtW2hv8QoDwng6JtEonmJoL3cNEwfd2cLXMpGezwZ2vL2dQ7259bueNKj9C8n",
     rootFingerprint: ROOT_FINGERPRINT,
     bip32Path: "m/45'",
   },
   testP2wshP2shOutput: {
-    xpub: 'Upub5T4XUooQzDXL58NCHk8ZCw9BsRSLCtnyHeZEExAq1XdnBFXiXVrHFuvvmh3TnCR7XmKHxkwqdACv68z7QKT1vwru9L1SZSsw8B2fuBvtSa6',
+    xpub:
+      "Upub5T4XUooQzDXL58NCHk8ZCw9BsRSLCtnyHeZEExAq1XdnBFXiXVrHFuvvmh3TnCR7XmKHxkwqdACv68z7QKT1vwru9L1SZSsw8B2fuBvtSa6",
     rootFingerprint: ROOT_FINGERPRINT,
     bip32Path: "m/48'/1'/0'/1'",
   },
 
   "m/45'/1/0": {
-    xpub : "tpubDDnpDVdDnpEnBgGkS2kRw2Fzqy1nB3TUGsT7whsuFDcqq4Xp9gsP6byEFqk9hGERapvSe8YRag3Jq4TjsbuZkY5TKkg14tW4jKdgUvy3jFr",
-    publicKey: "0349f15ab530552168983f0ba9d04f5fb5371d4713edc2efbedbffdeda1c08a861"
+    xpub:
+      "tpubDDnpDVdDnpEnBgGkS2kRw2Fzqy1nB3TUGsT7whsuFDcqq4Xp9gsP6byEFqk9hGERapvSe8YRag3Jq4TjsbuZkY5TKkg14tW4jKdgUvy3jFr",
+    publicKey:
+      "0349f15ab530552168983f0ba9d04f5fb5371d4713edc2efbedbffdeda1c08a861",
   },
   "m/45'/0": {
-    xpub : "tpubDBDZXR47BTgMPj4gTCUkp3BZniPMdEsRdzaxDAxnuQ5bk3n6LKLtqqYhxF53SjarCLU9evocxce8JynJ1sjybEPDdWupY6c1mFBEqLJwEAU",
-    publicKey: "0325b908dca32c9f789a96c836c5b9d31dd6f6abf122f430f5900209e009943f72"
+    xpub:
+      "tpubDBDZXR47BTgMPj4gTCUkp3BZniPMdEsRdzaxDAxnuQ5bk3n6LKLtqqYhxF53SjarCLU9evocxce8JynJ1sjybEPDdWupY6c1mFBEqLJwEAU",
+    publicKey:
+      "0325b908dca32c9f789a96c836c5b9d31dd6f6abf122f430f5900209e009943f72",
   },
 
   jsonConfigUUID: {
@@ -86,27 +106,30 @@ export const coldcardFixtures = {
     extendedPublicKeys: [
       {
         name: "unchained",
-        xpub: "tpubDF17mBZYUi35r7UEkGr7SjSisec8QL2J1zGh9WQtmnhJtHeMFy2eH2Xsnr2ynxENbqHmcEA4NnoT8T6RZxks4G5evZdWy1RbSPTm8LtNPU3",
+        xpub:
+          "tpubDF17mBZYUi35iCPDfFAa3jFd23L5ZF49tpS1AS1cEqNwhNaS8qVVD8ZPj67iKEarhPuMapZHuxr7TBDYA4DLxAoz25FN8ksyakdbc2V4X2Q",
         bip32Path: "Unknown",
-        xfp: "83471e78",
+        xfp: "77e80477",
       },
       {
-        name: "Os_words1",
-        xpub: "tpubDF61GHbPYRhEEsqNTDF2jbMBkEMmoksy1h2URbhZ8p7JfR9QRgbn6vkeA7g3t4Ue6uSHhYJxD9mRVz1ZQVYyW3RAPPuwVM4UeZyZPKu89DY",
-        bip32Path: "m/45'/1'/50'/0",
-        xfp: "f57ec65d",
+        name: "Os_words_pass_A",
+        xpub:
+          "tpubDEzYMGvKjbsnqEsjPvnG1TAxBGvk3EUJ9tqpTjnv6XEHktLASz8omNFS9VfSgbmpQWZefiRisKKCtERgsjsK39S6ueTHRXd8w5kNw8LzBoF",
+        bip32Path: "m/45'/1/0/0",
+        xfp: "39b12f98",
       },
       {
-        name: "Os_words2",
-        xpub: "tpubDEZxsxeamoPim6T1hg2igm4vDmdQrQnHVH5gM5NjcjowtgYVv5ZhhR5sFgRVNjRFGk1HmxsFsYhu3jGaAGVCpCsL5AbAVk6xKssr6gK3tPk",
-        bip32Path: "m/45'/1'/60'/0",
-        xfp: "f57ec65d",
+        name: "Os_words_pass_B",
+        xpub:
+          "tpubDF4Ar5bxLQV9qbr2bZ7N7TYYWNv28kPEChWwyvrrxTMKJjqsYhce79mUkLNiKpW121TshHwjZhZbHmT66oPbwLqxJzcXLyf32ubCJyr4pRR",
+        bip32Path: "m/45'/1/0/0",
+        xfp: "77d36d3b",
       },
     ],
     uuid: "OWPyFOA1",
   },
 
-  coldcardConfigUUID : `# Coldcard Multisig setup file (exported from unchained-wallets)
+  coldcardConfigUUID: `# Coldcard Multisig setup file (exported from unchained-wallets)
 # https://github.com/unchained-capital/unchained-wallets
 # v${COLDCARD_WALLET_CONFIG_VERSION}
 # 
@@ -114,12 +137,15 @@ Name: OWPyFOA1
 Policy: 2 of 3
 Format: P2SH
 
-83471e78: tpubDF17mBZYUi35r7UEkGr7SjSisec8QL2J1zGh9WQtmnhJtHeMFy2eH2Xsnr2ynxENbqHmcEA4NnoT8T6RZxks4G5evZdWy1RbSPTm8LtNPU3\r
-f57ec65d: tpubDF61GHbPYRhEEsqNTDF2jbMBkEMmoksy1h2URbhZ8p7JfR9QRgbn6vkeA7g3t4Ue6uSHhYJxD9mRVz1ZQVYyW3RAPPuwVM4UeZyZPKu89DY\r
-f57ec65d: tpubDEZxsxeamoPim6T1hg2igm4vDmdQrQnHVH5gM5NjcjowtgYVv5ZhhR5sFgRVNjRFGk1HmxsFsYhu3jGaAGVCpCsL5AbAVk6xKssr6gK3tPk\r
+Derivation: m/0/0/0/0
+77e80477: tpubDF17mBZYUi35iCPDfFAa3jFd23L5ZF49tpS1AS1cEqNwhNaS8qVVD8ZPj67iKEarhPuMapZHuxr7TBDYA4DLxAoz25FN8ksyakdbc2V4X2Q
+Derivation: m/45'/1/0/0
+39b12f98: tpubDEzYMGvKjbsnqEsjPvnG1TAxBGvk3EUJ9tqpTjnv6XEHktLASz8omNFS9VfSgbmpQWZefiRisKKCtERgsjsK39S6ueTHRXd8w5kNw8LzBoF
+Derivation: m/45'/1/0/0
+77d36d3b: tpubDF4Ar5bxLQV9qbr2bZ7N7TYYWNv28kPEChWwyvrrxTMKJjqsYhce79mUkLNiKpW121TshHwjZhZbHmT66oPbwLqxJzcXLyf32ubCJyr4pRR
 `,
 
-  coldcardConfigName : `# Coldcard Multisig setup file (exported from unchained-wallets)
+  coldcardConfigName: `# Coldcard Multisig setup file (exported from unchained-wallets)
 # https://github.com/unchained-capital/unchained-wallets
 # v${COLDCARD_WALLET_CONFIG_VERSION}
 # 
@@ -127,8 +153,11 @@ Name: Test
 Policy: 2 of 3
 Format: P2SH
 
-83471e78: tpubDF17mBZYUi35r7UEkGr7SjSisec8QL2J1zGh9WQtmnhJtHeMFy2eH2Xsnr2ynxENbqHmcEA4NnoT8T6RZxks4G5evZdWy1RbSPTm8LtNPU3\r
-f57ec65d: tpubDF61GHbPYRhEEsqNTDF2jbMBkEMmoksy1h2URbhZ8p7JfR9QRgbn6vkeA7g3t4Ue6uSHhYJxD9mRVz1ZQVYyW3RAPPuwVM4UeZyZPKu89DY\r
-f57ec65d: tpubDEZxsxeamoPim6T1hg2igm4vDmdQrQnHVH5gM5NjcjowtgYVv5ZhhR5sFgRVNjRFGk1HmxsFsYhu3jGaAGVCpCsL5AbAVk6xKssr6gK3tPk\r
-`
-}
+Derivation: m/0/0/0/0
+77e80477: tpubDF17mBZYUi35iCPDfFAa3jFd23L5ZF49tpS1AS1cEqNwhNaS8qVVD8ZPj67iKEarhPuMapZHuxr7TBDYA4DLxAoz25FN8ksyakdbc2V4X2Q
+Derivation: m/45'/1/0/0
+39b12f98: tpubDEzYMGvKjbsnqEsjPvnG1TAxBGvk3EUJ9tqpTjnv6XEHktLASz8omNFS9VfSgbmpQWZefiRisKKCtERgsjsK39S6ueTHRXd8w5kNw8LzBoF
+Derivation: m/45'/1/0/0
+77d36d3b: tpubDF4Ar5bxLQV9qbr2bZ7N7TYYWNv28kPEChWwyvrrxTMKJjqsYhce79mUkLNiKpW121TshHwjZhZbHmT66oPbwLqxJzcXLyf32ubCJyr4pRR
+`,
+};

--- a/src/coldcard.js
+++ b/src/coldcard.js
@@ -42,7 +42,7 @@ export const COLDCARD_BASE_BIP32_PATHS = {
 };
 const COLDCARD_BASE_CHROOTS = Object.keys(COLDCARD_BASE_BIP32_PATHS);
 
-export const COLDCARD_WALLET_CONFIG_VERSION = "0.0.2";
+export const COLDCARD_WALLET_CONFIG_VERSION = "1.0.0";
 
 /**
  * Base class for interactions with Coldcard


### PR DESCRIPTION
Coldcard released firmware [version 3.2.1](https://github.com/Coldcard/firmware/tree/2021-01-07T1439-v3.2.1) today. It has several multisig updates.

Originally we left out the `Derivation` parameter in our wallet config files (even though we had (and still have) access to it via what comes in) because the Coldcard was only paying attention to the first entry for `Derivation`. And in an effort to alleviate confusion (and because it wasn't a required parameter at the time), we left it out completely and happily continued with `Derivation: Unknown`.

Xpub specific derivations are now supported and `Derivation: Unknown` is no longer supported. Added logic to mask out the derivation to the proper depth (included in the xpub itself) if we do not know the bip32path for a particular xpub in the braid.

Another major change in the latest firmware update is that multiple xpubs from the same xfp are no longer supported. We had a fixture setup like this, so I updated the fixture.

More line changes than expected because I ran it through prettier.

I expect that we will be integrating changes from https://github.com/unchained-capital/unchained-wallets/pull/44 soon, but I wanted to go ahead and submit a solution to the current situation. I believe this does it. If you use the older firmware, it will only look at the first derivation path, but I believe that will be okay.