### PR TITLE
Adds "custom" text-based device and re-orders keystores alphabetically

### DIFF
--- a/fixtures/coldcard.fixtures.js
+++ b/fixtures/coldcard.fixtures.js
@@ -1,4 +1,4 @@
-import { COLDCARD_WALLET_CONFIG_VERSION } from "./coldcard";
+import { COLDCARD_WALLET_CONFIG_VERSION } from "../src";
 
 import { ROOT_FINGERPRINT } from "unchained-bitcoin";
 

--- a/fixtures/custom.fixtures.js
+++ b/fixtures/custom.fixtures.js
@@ -12,6 +12,7 @@ export const customFixtures = {
     xpub: nodes[P2SH_BASE_TEST].xpub,
     rootFingerprint: ROOT_FINGERPRINT,
   },
+
   validCustomXpubJSON: {
     bip32Path: P2SH_BASE_MAIN,
     xpub: nodes[P2SH_BASE_MAIN].xpub,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8004,9 +8004,9 @@
       "dev": true
     },
     "unchained-bitcoin": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.1.0.tgz",
-      "integrity": "sha512-LfeUIRF9k2rUQDbpa62tiZaNJqJBKp+WX99gwF77yx2+XoKiVHLJSnDKbYJ9DHAiUgoQRRvN6CG0tJNsiLF39Q==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.1.3.tgz",
+      "integrity": "sha512-6y/ieRdx330391Gk5rlYh28xsU7abUCsa77FtbT/3hlGBHGdBi1Y4n/Vp2eRAyAYrV6seZvds7Asi98q7EMo5A==",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "bignumber.js": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pako": "^1.0.10",
     "punycode": "^2.1.1",
     "trezor-connect": "^8.1.19",
-    "unchained-bitcoin": "^0.1.0"
+    "unchained-bitcoin": "^0.1.3"
   },
   "directories": {
     "lib": "lib"

--- a/src/coldcard.test.js
+++ b/src/coldcard.test.js
@@ -16,7 +16,7 @@ import {
   ACTIVE,
   ERROR,
 } from './interaction';
-import {coldcardFixtures} from './coldcard.fixtures';
+import { coldcardFixtures } from "../fixtures/coldcard.fixtures";
 
 const {multisigs, transactions} = TEST_FIXTURES;
 

--- a/src/custom.fixtures.js
+++ b/src/custom.fixtures.js
@@ -1,0 +1,34 @@
+import { TEST_FIXTURES, ROOT_FINGERPRINT } from "unchained-bitcoin";
+
+const { nodes } = TEST_FIXTURES.keys.open_source;
+
+const P2SH_BASE_MAIN = "m/45'/0'/0'";
+const P2SH_BASE_TEST = "m/45'/1'/0'";
+
+export const customFixtures = {
+  // These use the Open Source Wallet words from the `unchained-bitcoin` fixtures
+  validCustomTpubJSON: {
+    bip32Path: P2SH_BASE_TEST,
+    xpub: nodes[P2SH_BASE_TEST].xpub,
+    rootFingerprint: ROOT_FINGERPRINT,
+  },
+  validCustomXpubJSON: {
+    bip32Path: P2SH_BASE_MAIN,
+    xpub: nodes[P2SH_BASE_MAIN].xpub,
+    rootFingerprint: ROOT_FINGERPRINT,
+  },
+
+  validTpubFakeRootFingerprintOutput: {
+    xpub:
+      "tpubDDQubdBx9cbs16zUhpiM135EpvjSbVz7SGJyGg4rvRVEYdncZy3Kzjg6NjuFWcShiCyNqviWTBiZPb25p4WcaLppVmAuiPMrkR1kahNoioL",
+    bip32Path: P2SH_BASE_TEST,
+    rootFingerprint: "0b287198",
+  },
+
+  validXpubFakeRootFingerprintOutput: {
+    xpub:
+      "xpub6CCHViYn5VzKFqrKjAzSSqP8XXSU5fEC6ZYSncX5pvSKoRLrPDcF8cEaZkrQvvnuwRUXeKVjoGmAqvbwVkNBFLaRiqcdVhWPyuShUrbcZsv",
+    bip32Path: P2SH_BASE_MAIN,
+    rootFingerprint: "266afe03",
+  },
+};

--- a/src/custom.js
+++ b/src/custom.js
@@ -1,0 +1,272 @@
+/**
+ * Provides classes for interacting via text-based copy/paste XPUBs and
+ * download/sign generic PSBT files using a custom "device'
+ *
+ * The following API classes are implemented:
+ *
+ * * CustomExportExtendedPublicKey
+ * * CustomSignMultisigTransaction
+ *
+ * @module custom
+ */
+import {
+  unsignedMultisigPSBT,
+  parseSignaturesFromPSBT,
+  MAINNET,
+  TESTNET,
+  validateBIP32Path,
+  validateRootFingerprint,
+  ExtendedPublicKey,
+} from "unchained-bitcoin";
+import {
+  IndirectKeystoreInteraction,
+  PENDING,
+  ACTIVE,
+  INFO,
+  ERROR,
+} from "./interaction";
+
+export const CUSTOM = "custom";
+
+/**
+ * Base class for interactions with Custom "devices"
+ *
+ * @extends {module:interaction.IndirectKeystoreInteraction}
+ */
+export class CustomInteraction extends IndirectKeystoreInteraction {}
+
+/**
+ * Base class for text-based (or clipboard pasted) ExtendedPublicKey
+ * This class handles parsing/validating the xpub and relevant
+ * derivation properties. If no root fingerprint is provided, one will
+ * be deterministically assigned.
+ *
+ * @extends {module:custom.CustomInteraction}
+ * @example
+ * const interaction = new CustomExportExtendedPublicKey({network: MAINNET, bip32Path: "m/45'/0'/0'"});
+ * const {xpub, rootFingerprint, bip32Path} = interaction.parse({xpub: xpub..., rootFingerprint: 0f056943});
+ * console.log(xpub);
+ * // "xpub..."
+ * console.log(rootFingerprint);
+ * // "0f056943"
+ * console.log(bip32Path);
+ * // "m/45'/0'/0'"
+ * ** OR **
+ * * const {xpub, rootFingerprint, bip32Path} = interaction.parse({xpub: xpub...});
+ * console.log(xpub);
+ * // "xpub..."
+ * console.log(rootFingerprint);
+ * // "096aed5e"
+ * console.log(bip32Path);
+ * // "m/45'/0'/0'"
+ */
+export class CustomExportExtendedPublicKey extends CustomInteraction {
+  /**
+   * @param {object} options - options argument
+   * @param {string} options.network - bitcoin network (needed for derivations)
+   * @param {string} options.bip32Path - bip32Path to interrogate
+   */
+  constructor({ network, bip32Path }) {
+    super();
+    if ([MAINNET, TESTNET].find((net) => net === network)) {
+      this.network = network;
+    } else {
+      throw new Error("Unknown network.");
+    }
+    this.validationErrorMessages = [];
+    this.bip32Path = bip32Path;
+    const bip32PathError = validateBIP32Path(bip32Path);
+    if (bip32PathError.length) {
+      this.validationErrorMessages.push({
+        code: "custom.bip32_path.path_error",
+        text: bip32PathError,
+      });
+    }
+  }
+
+  isSupported() {
+    return this.validationErrorMessages.length === 0;
+  }
+
+  messages() {
+    const messages = super.messages();
+
+    if (this.validationErrorMessages.length) {
+      this.validationErrorMessages.map((e) => {
+        messages.push({
+          state: PENDING,
+          level: ERROR,
+          code: e.code,
+          text: e.text,
+        });
+      });
+    }
+
+    messages.push({
+      state: PENDING,
+      level: INFO,
+      code: "custom.import_xpub",
+      text: "Type or paste the extended public key here.",
+    });
+    return messages;
+  }
+
+  /**
+   * Parse the provided JSON and do some basic error checking
+   *
+   * @param {Object} data - JSON object with incoming data to be parsed (read: reformatted)
+   * @returns {Object} Object - ExtendedPublicKeyDerivation {xpub, bip32path, rootFingerprint}
+   */
+  parse(data) {
+    // build ExtendedPublicKey struct (validation happens in constructor)
+    let xpubClass;
+    let rootFingerprint;
+    try {
+      xpubClass = ExtendedPublicKey.fromBase58(data.xpub);
+    } catch (e) {
+      throw new Error("Not a valid ExtendedPublicKey.");
+    }
+    try {
+      const pkLen = xpubClass.pubkey.length;
+      // If no fingerprint is provided, we will assign one deterministically
+      const fakeRootFingerprint = xpubClass.pubkey.substring(pkLen - 8);
+
+      if (data.rootFingerprint === "" || data.rootFingerprint === undefined) {
+        rootFingerprint = fakeRootFingerprint;
+      } else {
+        validateRootFingerprint(data.rootFingerprint);
+        rootFingerprint = data.rootFingerprint;
+      }
+    } catch (e) {
+      throw new Error(
+        `Root fingerprint validation error: ${e.message.toLowerCase()}.`
+      );
+    }
+    const numSlashes = this.bip32Path.split("/").length;
+    const bipDepth = this.bip32Path.startsWith("m/")
+      ? numSlashes - 1
+      : numSlashes;
+
+    if (xpubClass.depth !== bipDepth) {
+      throw new Error(
+        `Depth of ExtendedPublicKey (${xpubClass.depth}) does not match depth of BIP32 path (${bipDepth}).`
+      );
+    }
+
+    return {
+      xpub: xpubClass.base58String,
+      rootFingerprint,
+      bip32Path: this.bip32Path,
+    };
+  }
+}
+
+/**
+ * Returns signature request data via a PSBT for a Custom "device" to sign and
+ * accepts a PSBT for parsing signatures from a Custom "device"
+ *
+ * @extends {module:custom.CustomInteraction}
+ * @example
+ * const interaction = new CustomSignMultisigTransaction({network, inputs, outputs, bip32paths, psbt});
+ * console.log(interaction.request());
+ * // "cHNidP8BA..."
+ *
+ * // Parse signatures from a signed PSBT
+ * const signatures = interaction.parse(psbt);
+ * console.log(signatures);
+ * // {'029e866...': ['3045...01', ...]}
+ *
+ */
+export class CustomSignMultisigTransaction extends CustomInteraction {
+  /**
+   * @param {object} options - options argument
+   * @param {string} options.network - bitcoin network
+   * @param {array<object>} options.inputs - inputs for the transaction
+   * @param {array<object>} options.outputs - outputs for the transaction
+   * @param {array<string>} options.bip32Paths - BIP32 paths
+   * @param {object} [options.psbt] - PSBT of the transaction to sign, included or generated from the other options
+   */
+  constructor({ network, inputs, outputs, bip32Paths, psbt }) {
+    super();
+    this.network = network;
+    this.inputs = inputs;
+    this.outputs = outputs;
+    this.bip32Paths = bip32Paths;
+
+    if (psbt) {
+      this.psbt = psbt;
+    } else {
+      try {
+        this.psbt = unsignedMultisigPSBT(network, inputs, outputs);
+      } catch (e) {
+        throw new Error(
+          "Unable to build the PSBT from the provided parameters."
+        );
+      }
+    }
+  }
+
+  messages() {
+    const messages = super.messages();
+    messages.push({
+      state: PENDING,
+      level: INFO,
+      code: "custom.download_psbt",
+      text: `Download and save this PSBT file.`,
+    });
+    messages.push({
+      state: PENDING,
+      level: INFO,
+      code: "custom.sign_psbt",
+      text: `Add your signature to the PSBT.`,
+    });
+    messages.push({
+      state: ACTIVE,
+      level: INFO,
+      code: "custom.sign_psbt",
+      text: `Verify the transaction details and sign.`,
+    });
+    messages.push({
+      state: ACTIVE,
+      level: INFO,
+      code: "custom.upload_signed_psbt",
+      text: `Upload the signed PSBT.`,
+    });
+    return messages;
+  }
+
+  /**
+   * Request for the PSBT data that needs to be signed.
+   *
+   * NOTE: the application may be expecting the PSBT in some format
+   * other than the direct Object.
+   *
+   * E.g. PSBT in Base64 is interaction().request().toBase64()
+   *
+   * @returns {Object} Returns the local unsigned PSBT from transaction details
+   */
+  request() {
+    return this.psbt;
+  }
+
+  /**
+   *
+   * @param {Object} psbtObject - the PSBT
+   * @returns {Object} signatures - This calls a function in unchained-bitcoin which parses
+   * PSBT files for sigantures and then returns an object with the format
+   * {
+   *   pubkey1 : [sig1, sig2, ...],
+   *   pubkey2 : [sig1, sig2, ...]
+   * }
+   * This format may change in the future or there may be additional options for return type.
+   */
+  parse(psbtObject) {
+    const signatures = parseSignaturesFromPSBT(psbtObject);
+    if (!signatures || signatures.length === 0) {
+      throw new Error(
+        "No signatures found in the PSBT. Did you upload the right one?"
+      );
+    }
+    return signatures;
+  }
+}

--- a/src/custom.js
+++ b/src/custom.js
@@ -92,7 +92,7 @@ export class CustomExportExtendedPublicKey extends CustomInteraction {
     const messages = super.messages();
 
     if (this.validationErrorMessages.length) {
-      this.validationErrorMessages.map((e) => {
+      this.validationErrorMessages.forEach((e) => {
         messages.push({
           state: PENDING,
           level: ERROR,
@@ -127,12 +127,10 @@ export class CustomExportExtendedPublicKey extends CustomInteraction {
       throw new Error("Not a valid ExtendedPublicKey.");
     }
     try {
-      const pkLen = xpubClass.pubkey.length;
-      // If no fingerprint is provided, we will assign one deterministically
-      const fakeRootFingerprint = xpubClass.pubkey.substring(pkLen - 8);
-
       if (data.rootFingerprint === "" || data.rootFingerprint === undefined) {
-        rootFingerprint = fakeRootFingerprint;
+        const pkLen = xpubClass.pubkey.length;
+        // If no fingerprint is provided, we will assign one deterministically
+        rootFingerprint = xpubClass.pubkey.substring(pkLen - 8);
       } else {
         validateRootFingerprint(data.rootFingerprint);
         rootFingerprint = data.rootFingerprint;

--- a/src/custom.test.js
+++ b/src/custom.test.js
@@ -1,0 +1,263 @@
+import {
+  CustomExportExtendedPublicKey,
+  CustomSignMultisigTransaction,
+} from "./custom";
+import { MAINNET, TESTNET, TEST_FIXTURES } from "unchained-bitcoin";
+import { INFO, PENDING, ACTIVE, ERROR } from "./interaction";
+import { customFixtures } from "./custom.fixtures";
+
+const { multisigs, transactions } = TEST_FIXTURES;
+
+describe("CustomExportExtendedPublicKey", () => {
+  function interactionBuilder({ bip32Path, network }) {
+    return new CustomExportExtendedPublicKey({
+      bip32Path,
+      network,
+    });
+  }
+
+  describe("constructor", () => {
+    it("fails with invalid network", () => {
+      expect(() => interactionBuilder({ network: "foob" })).toThrow(
+        /Unknown network/i
+      );
+    });
+    it("invalid bip32Path unsupported", () => {
+      const interaction = interactionBuilder({
+        network: TESTNET,
+        bip32Path: "m/45'/1/01",
+      });
+      expect(interaction.isSupported()).toBe(false);
+      expect(
+        interaction.hasMessagesFor({
+          state: PENDING,
+          level: ERROR,
+          code: "custom.bip32_path.path_error",
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe("parse", () => {
+    it("fails when sending in nothing or non json", () => {
+      const notJSON = "test";
+      const definitelyNotJSON = 77;
+      const interaction = interactionBuilder({
+        network: TESTNET,
+        bip32Path: "m/45'/1/0",
+      });
+      expect(() => interaction.parse(notJSON)).toThrow(
+        /Not a valid ExtendedPublicKey/i
+      );
+      expect(() => interaction.parse(definitelyNotJSON)).toThrow(
+        /Not a valid ExtendedPublicKey/i
+      );
+      expect(() => interaction.parse({})).toThrow(
+        /Not a valid ExtendedPublicKey/i
+      );
+    });
+
+    it("fails when missing xpub field", () => {
+      const interaction = interactionBuilder({
+        network: MAINNET,
+        bip32Path: "m/45'/1'/0'",
+      });
+      const missingXpub = {
+        ...customFixtures.validCustomTpubJSON,
+      };
+      Reflect.deleteProperty(missingXpub, "xpub");
+      expect(() => interaction.parse(missingXpub)).toThrow(
+        /Not a valid ExtendedPublicKey/i
+      );
+    });
+
+    it("testnet no rootFingerprint is included so it gets computed", () => {
+      const bip32Path = "m/45'/0'/0'";
+      const interaction = interactionBuilder({
+        network: TESTNET,
+        bip32Path,
+      });
+      const missingXfp = { ...customFixtures.validCustomXpubJSON };
+      Reflect.deleteProperty(missingXfp, "rootFingerprint");
+      const result = interaction.parse(missingXfp);
+
+      expect(result).toEqual(customFixtures.validXpubFakeRootFingerprintOutput);
+    });
+
+    it("mainnet no rootFingerprint is included so it gets computed", () => {
+      const bip32Path = "m/45'/1'/0'";
+      const interaction = interactionBuilder({
+        network: TESTNET,
+        bip32Path,
+      });
+      const missingXfp = { ...customFixtures.validCustomTpubJSON };
+      Reflect.deleteProperty(missingXfp, "rootFingerprint");
+      const result = interaction.parse(missingXfp);
+
+      expect(result).toEqual(customFixtures.validTpubFakeRootFingerprintOutput);
+    });
+
+    it("invalid rootFingerprint included", () => {
+      const bip32Path = "m/45'/1'/0'";
+      const interaction = interactionBuilder({
+        network: TESTNET,
+        bip32Path,
+      });
+      expect(() =>
+        interaction.parse({
+          xpub: customFixtures.validCustomTpubJSON.xpub,
+          rootFingerprint: "zzzz",
+        })
+      ).toThrow(/Root fingerprint validation error/i);
+    });
+
+    it("should error as bip32 depth does not match depth in xpub param", () => {
+      let bip32Path = "m/45'";
+      const interaction = interactionBuilder({
+        network: TESTNET,
+        bip32Path,
+      });
+
+      expect(() =>
+        interaction.parse(customFixtures.validCustomTpubJSON)
+      ).toThrow(/does not match depth of BIP32 path/i);
+    });
+
+    it("should error as bip32 depth does not match depth in xpub param (bip32 missing m/ for whatever reason)", () => {
+      let bip32Path = "45'/0'";
+      const interaction = interactionBuilder({
+        network: TESTNET,
+        bip32Path,
+      });
+
+      expect(() =>
+        interaction.parse(customFixtures.validCustomTpubJSON)
+      ).toThrow(/does not match depth of BIP32 path/i);
+    });
+  });
+
+  it("has a message about uploading file", () => {
+    expect(
+      interactionBuilder({
+        network: TESTNET,
+        bip32Path: "m/45'",
+      }).hasMessagesFor({
+        state: PENDING,
+        level: INFO,
+        code: "custom.import_xpub",
+        text: "Type or paste the extended public key here.",
+      })
+    ).toBe(true);
+  });
+});
+
+describe("CustomSignMultisigTransaction", () => {
+  function interactionBuilder({ network, inputs, outputs, bip32Paths, psbt }) {
+    return new CustomSignMultisigTransaction({
+      network,
+      inputs,
+      outputs,
+      bip32Paths,
+      psbt,
+    });
+  }
+  describe("constructor", () => {
+    it("fails when sending in no psbt", () => {
+      expect(() => interactionBuilder({})).toThrow(/Unable to build the PSBT/i);
+    });
+  });
+
+  describe("request", () => {
+    it("return psbt if there is one", () => {
+      const interaction = interactionBuilder({
+        network: TESTNET,
+        psbt: multisigs[0].psbt,
+      });
+      const result = interaction.request();
+      expect(result).toEqual(multisigs[0].psbt);
+    });
+
+    it("construct psbt if there is not one", () => {
+      const interaction = interactionBuilder({
+        network: transactions[0].network,
+        inputs: transactions[0].inputs,
+        outputs: transactions[0].outputs,
+        bip32Paths: transactions[0].bip32Paths,
+      });
+      const result = interaction.request().toBase64();
+      expect(result).toEqual(transactions[0].psbt);
+    });
+  });
+
+  describe("parse", () => {
+    it("return multi input, single signature set", () => {
+      const interaction = interactionBuilder({
+        psbt: multisigs[0].psbtPartiallySigned,
+      });
+      const result = interaction.parse(multisigs[0].psbtPartiallySigned);
+      const signatureSet = {};
+      signatureSet[multisigs[0].publicKey] = multisigs[0].transaction.signature;
+      expect(result).toEqual(signatureSet);
+      expect(Object.keys(result).length).toEqual(1);
+    });
+    it("psbt has no signatures", () => {
+      const interaction = interactionBuilder({ psbt: multisigs[0].psbt });
+      expect(() => interaction.parse(multisigs[0].psbt)).toThrow(
+        /No signatures found/i
+      );
+    });
+  });
+
+  it("has a message about downloading psbt", () => {
+    expect(
+      interactionBuilder({
+        network: TESTNET,
+        psbt: multisigs[0].psbt,
+      }).hasMessagesFor({
+        state: PENDING,
+        level: INFO,
+        code: "custom.download_psbt",
+        text: "Download and save this PSBT file.",
+      })
+    ).toBe(true);
+  });
+  it("has a message about signing psbt", () => {
+    expect(
+      interactionBuilder({
+        network: TESTNET,
+        psbt: multisigs[0].psbt,
+      }).hasMessagesFor({
+        state: PENDING,
+        level: INFO,
+        code: "custom.sign_psbt",
+        text: `Add your signature to the PSBT.`,
+      })
+    ).toBe(true);
+  });
+  it("has a message about verify tx", () => {
+    expect(
+      interactionBuilder({
+        network: TESTNET,
+        psbt: multisigs[0].psbt,
+      }).hasMessagesFor({
+        state: ACTIVE,
+        level: INFO,
+        code: "custom.sign_psbt",
+        text: "Verify the transaction details and sign.",
+      })
+    ).toBe(true);
+  });
+  it("has a message about upload PSBT", () => {
+    expect(
+      interactionBuilder({
+        network: TESTNET,
+        psbt: multisigs[0].psbt,
+      }).hasMessagesFor({
+        state: ACTIVE,
+        level: INFO,
+        code: "custom.upload_signed_psbt",
+        text: "Upload the signed PSBT.",
+      })
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
We need to support custom flows for text-based xpub upload and custom PSBT signing, so I have created the interaction classes below to support these use cases.

Includes unit tests and fixture data.

![Screen Shot 2021-02-12 at 12 58 15 PM](https://user-images.githubusercontent.com/10471648/107821831-f9667a80-6d31-11eb-8ba8-9aec60232d72.png)

I have also edited the exports and deciding device interaction class such that they're in alphabetic order. This will cause conflicts when merging into other existing PRs, but as we add more keystores, this will be a nice thing to keep in mind.

If we think it will cause too much hassle, lmk and I can remove it.
