### PR TITLE
Peg Ledger WebUSB to version `5.53.0` until Chromium releases their patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ledgerhq/hw-app-btc": "^5.34.1",
     "@ledgerhq/hw-transport-node-hid": "^5.34.0",
     "@ledgerhq/hw-transport-u2f": "^5.34.0",
-    "@ledgerhq/hw-transport-webusb": "^5.51.3",
+    "@ledgerhq/hw-transport-webusb": "5.53.0",
     "bignumber.js": "^8.1.1",
     "bitcoinjs-lib": "^4.0.5",
     "bowser": "^2.6.1",


### PR DESCRIPTION
In order for us to release any updates to Caravan, we need to peg the ledger-webusb npm package to `0.53.0` because they reverted that fix in `0.53.1` and it's just broken and they're waiting on Chromium to release.

Things work fine for us on this patched version, so let's stay here until after Chromium releases a patch or Ledger figures out another fix.

The lock file already has this version, so no changes expected there.