### PR TITLE
Adds support for Ledger/Trezor PSBT signing for P2SH case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8008,9 +8008,9 @@
       "dev": true
     },
     "unchained-bitcoin": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.1.3.tgz",
-      "integrity": "sha512-6y/ieRdx330391Gk5rlYh28xsU7abUCsa77FtbT/3hlGBHGdBi1Y4n/Vp2eRAyAYrV6seZvds7Asi98q7EMo5A==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.1.8.tgz",
+      "integrity": "sha512-oHlK48NaQK7hVfg+/9ADulNmEJ2sxVUZlBH4BiVZldl5Nzs5EQ4nJSOXo9DBSq6wn+M86X6uxTsgAwEA8Lpm6w==",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "bignumber.js": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pako": "^1.0.10",
     "punycode": "^2.1.1",
     "trezor-connect": "^8.1.19",
-    "unchained-bitcoin": "^0.1.3"
+    "unchained-bitcoin": "^0.1.8"
   },
   "directories": {
     "lib": "lib"

--- a/src/coldcard.js
+++ b/src/coldcard.js
@@ -58,6 +58,7 @@ export class ColdcardInteraction extends IndirectKeystoreInteraction {}
  * @extends {module:coldcard.ColdcardInteraction}
  */
 class ColdcardMultisigSettingsFileParser extends ColdcardInteraction {
+
   /**
    * @param {object} options - options argument
    * @param {string} options.network - bitcoin network (needed for derivations)
@@ -316,6 +317,7 @@ class ColdcardMultisigSettingsFileParser extends ColdcardInteraction {
  * // "m/45'/0/0"
  */
 export class ColdcardExportPublicKey extends ColdcardMultisigSettingsFileParser {
+
   /**
    *
    * @param {object} options - options argument
@@ -363,6 +365,7 @@ export class ColdcardExportPublicKey extends ColdcardMultisigSettingsFileParser 
  * // "m/45'/0/0"
  */
 export class ColdcardExportExtendedPublicKey extends ColdcardMultisigSettingsFileParser {
+
   /**
    *
    * @param {object} options - options argument
@@ -409,6 +412,7 @@ export class ColdcardExportExtendedPublicKey extends ColdcardMultisigSettingsFil
  *
  */
 export class ColdcardSignMultisigTransaction extends ColdcardInteraction {
+
   /**
    *
    * @param {object} options - options argument

--- a/src/custom.js
+++ b/src/custom.js
@@ -61,6 +61,7 @@ export class CustomInteraction extends IndirectKeystoreInteraction {}
  * // "m/45'/0'/0'"
  */
 export class CustomExportExtendedPublicKey extends CustomInteraction {
+
   /**
    * @param {object} options - options argument
    * @param {string} options.network - bitcoin network (needed for derivations)
@@ -127,7 +128,7 @@ export class CustomExportExtendedPublicKey extends CustomInteraction {
       throw new Error("Not a valid ExtendedPublicKey.");
     }
     try {
-      if (data.rootFingerprint === "" || data.rootFingerprint === undefined) {
+      if (data.rootFingerprint === "" || !data.rootFingerprint) {
         const pkLen = xpubClass.pubkey.length;
         // If no fingerprint is provided, we will assign one deterministically
         rootFingerprint = xpubClass.pubkey.substring(pkLen - 8);
@@ -176,6 +177,7 @@ export class CustomExportExtendedPublicKey extends CustomInteraction {
  *
  */
 export class CustomSignMultisigTransaction extends CustomInteraction {
+
   /**
    * @param {object} options - options argument
    * @param {string} options.network - bitcoin network

--- a/src/custom.test.js
+++ b/src/custom.test.js
@@ -103,8 +103,7 @@ describe("CustomExportExtendedPublicKey", () => {
         network: TESTNET,
         bip32Path,
       });
-      expect(() =>
-        interaction.parse({
+      expect(() => interaction.parse({
           xpub: customFixtures.validCustomTpubJSON.xpub,
           rootFingerprint: "zzzz",
         })
@@ -118,8 +117,7 @@ describe("CustomExportExtendedPublicKey", () => {
         bip32Path,
       });
 
-      expect(() =>
-        interaction.parse(customFixtures.validCustomTpubJSON)
+      expect(() => interaction.parse(customFixtures.validCustomTpubJSON)
       ).toThrow(/does not match depth of BIP32 path/i);
     });
 
@@ -130,8 +128,7 @@ describe("CustomExportExtendedPublicKey", () => {
         bip32Path,
       });
 
-      expect(() =>
-        interaction.parse(customFixtures.validCustomTpubJSON)
+      expect(() => interaction.parse(customFixtures.validCustomTpubJSON)
       ).toThrow(/does not match depth of BIP32 path/i);
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -244,6 +244,8 @@ export function ExportExtendedPublicKey({
  * @param {object[]} options.inputs - transaction inputs
  * @param {object[]} options.outputs - transaction outputs
  * @param {string[]} options.bip32Paths - the BIP32 paths on this device corresponding to a public key in each input
+ * @param {string} [options.psbt] - the unsigned_psbt
+ * @param {object} [options.keyDetails] - Signing Key Fingerprint + Bip32 Root
  * @return {module:interaction.KeystoreInteraction} keystore-specific interaction instance
  * @example
  * import {
@@ -286,6 +288,7 @@ export function SignMultisigTransaction({
   outputs,
   bip32Paths,
   psbt,
+  keyDetails,
 }) {
   switch (keystore) {
     case COLDCARD:
@@ -316,6 +319,8 @@ export function SignMultisigTransaction({
         inputs,
         outputs,
         bip32Paths,
+        psbt,
+        keyDetails,
       });
     case TREZOR:
       return new TrezorSignMultisigTransaction({

--- a/src/index.js
+++ b/src/index.js
@@ -246,6 +246,7 @@ export function ExportExtendedPublicKey({
  * @param {string[]} options.bip32Paths - the BIP32 paths on this device corresponding to a public key in each input
  * @param {string} [options.psbt] - the unsigned_psbt
  * @param {object} [options.keyDetails] - Signing Key Fingerprint + Bip32 Root
+ * @param {boolean} [options.returnSignatureArray] - return an array of signatures instead of a signed PSBT (useful for test suite)
  * @return {module:interaction.KeystoreInteraction} keystore-specific interaction instance
  * @example
  * import {
@@ -289,6 +290,7 @@ export function SignMultisigTransaction({
   bip32Paths,
   psbt,
   keyDetails,
+  returnSignatureArray= false,
 }) {
   switch (keystore) {
     case COLDCARD:
@@ -321,6 +323,7 @@ export function SignMultisigTransaction({
         bip32Paths,
         psbt,
         keyDetails,
+        returnSignatureArray,
       });
     case TREZOR:
       return new TrezorSignMultisigTransaction({

--- a/src/index.js
+++ b/src/index.js
@@ -331,6 +331,9 @@ export function SignMultisigTransaction({
         inputs,
         outputs,
         bip32Paths,
+        psbt,
+        keyDetails,
+        returnSignatureArray,
       });
     default:
       return new UnsupportedInteraction({

--- a/src/ledger.js
+++ b/src/ledger.js
@@ -30,7 +30,6 @@ import {
   getFingerprintFromPublicKey,
   deriveExtendedPublicKey,
   unsignedMultisigTransaction,
-  signatureNoSighashType,
   validateBIP32Path,
   fingerprintToFixedLengthHex,
   translatePSBT,
@@ -1009,16 +1008,6 @@ export class LedgerSignMultisigTransaction extends LedgerBitcoinInteraction {
         transport.close();
       }
     });
-  }
-
-  signatureFormatter(inputSignature, format) {
-    // Ledger signatures include the SIGHASH byte (0x01) if signing for P2SH-P2WSH or P2WSH ...
-    // but NOT for P2SH ... This function should always return the signature with SIGHASH byte appended.
-    return format === "buffer" ? Buffer.from(`${signatureNoSighashType(inputSignature)}01`, "hex") : `${signatureNoSighashType(inputSignature)}01`;
-  }
-
-  parseSignature(transactionSignature, format="hex") {
-    return (transactionSignature || []).map(inputSignature => this.signatureFormatter(inputSignature, format));
   }
 
   ledgerInputs() {

--- a/src/ledger.js
+++ b/src/ledger.js
@@ -827,13 +827,13 @@ export class LedgerSignMultisigTransaction extends LedgerBitcoinInteraction {
       this.bip32Paths = bip32Paths;
     } else {
       const {
-        txInputs,
-        txOutputs,
+        unchainedInputs,
+        unchainedOutputs,
         bip32Derivations
       } = translatePSBT(network, P2SH, psbt, keyDetails);
       this.psbt = psbt;
-      this.inputs = txInputs;
-      this.outputs = txOutputs;
+      this.inputs = unchainedInputs;
+      this.outputs = unchainedOutputs;
       this.bip32Paths = bip32Derivations.map((b32d) => b32d.path);
       this.pubkeys = bip32Derivations.map((b32d) => b32d.pubkey);
     }

--- a/src/ledger.js
+++ b/src/ledger.js
@@ -116,7 +116,7 @@ export const LEDGER_BOTH_BUTTONS = 'ledger_both_buttons';
  *       return app.doSomething(this.param); // Not a real Ledger API call
  *     });
  *   }
- * 
+ *
  * }
  *
  * // usage
@@ -817,8 +817,9 @@ export class LedgerSignMultisigTransaction extends LedgerBitcoinInteraction {
    * @param {array<string>} [options.bip32Paths] - BIP32 paths
    * @param {string} [options.psbt] - PSBT string encoded in base64
    * @param {object} [options.keyDetails] - Signing Key Details (Fingerprint + bip32 prefix)
+   * @param {boolean} [options.returnSignatureArray] - return an array of signatures instead of a signed PSBT (useful for test suite)
    */
-  constructor({network, inputs, outputs, bip32Paths, psbt, keyDetails}) {
+  constructor({network, inputs, outputs, bip32Paths, psbt, keyDetails, returnSignatureArray= false}) {
     super();
     this.network = network;
     if (!psbt || !keyDetails) {
@@ -836,6 +837,7 @@ export class LedgerSignMultisigTransaction extends LedgerBitcoinInteraction {
       this.outputs = unchainedOutputs;
       this.bip32Paths = bip32Derivations.map((b32d) => b32d.path);
       this.pubkeys = bip32Derivations.map((b32d) => b32d.pubkey);
+      this.returnSignatureArray = returnSignatureArray;
     }
   }
 
@@ -998,7 +1000,7 @@ export class LedgerSignMultisigTransaction extends LedgerBitcoinInteraction {
 
         // If we were passed a PSBT initially, we want to return a PSBT with partial signatures
         // rather than the normal array of signatures.
-        if (this.psbt) {
+        if (this.psbt && !this.returnSignatureArray) {
           return addSignaturesToPSBT(this.network, this.psbt, this.pubkeys, this.parseSignature(transactionSignature, "buffer"))
         } else {
           return this.parseSignature(transactionSignature, "hex");

--- a/src/ledger.test.js
+++ b/src/ledger.test.js
@@ -248,7 +248,7 @@ describe('ledger', () => {
     const tx = TEST_FIXTURES.transactions[0];
     const keyDetails = {
       xfp: ROOT_FINGERPRINT,
-      root: "m/45'/1'/100'",
+      path: "m/45'/1'/100'",
     };
     function psbtInteractionBuilder() { return new LedgerSignMultisigTransaction({
       network: tx.network,

--- a/src/ledger.test.js
+++ b/src/ledger.test.js
@@ -1,5 +1,6 @@
 import {
   TEST_FIXTURES,
+  ROOT_FINGERPRINT,
 } from "unchained-bitcoin";
 import {
   PENDING,
@@ -244,6 +245,21 @@ describe('ledger', () => {
       });
     });
 
+    const tx = TEST_FIXTURES.transactions[0];
+    const keyDetails = {
+      xfp: ROOT_FINGERPRINT,
+      root: "m/45'/1'/100'",
+    };
+    function psbtInteractionBuilder() { return new LedgerSignMultisigTransaction({
+      network: tx.network,
+      inputs: [],
+      outputs: [],
+      bip32Paths: [],
+      psbt: tx.psbt,
+      keyDetails,
+    }); }
+
+    itHasAppMessages(psbtInteractionBuilder);
 
   });
 

--- a/src/ledger.test.js
+++ b/src/ledger.test.js
@@ -234,12 +234,12 @@ describe('ledger', () => {
           //   second byte is length of signature in bytes (0x03)
           // The string length is however long the signature is minus these two starting bytes
           // plain signature without SIGHASH (foobar is 3 bytes, string length = 6, which is 3 bytes)
-          expect(interactionBuilder().parse(["3003foobar"])).toEqual(["3003foobar01"]);
+          expect(interactionBuilder().parseSignature(["3003foobar"])).toEqual(["3003foobar01"]);
           // signature actually ends in 0x01 (foob01 is 3 bytes, string length = 6, which is 3 bytes)
-          expect(interactionBuilder().parse(["3003foob01"])).toEqual(["3003foob0101"]);
+          expect(interactionBuilder().parseSignature(["3003foob01"])).toEqual(["3003foob0101"]);
           // signature with sighash already included (foobar is 3 bytes, string length = 8, which is 4 bytes) ...
           // we expect this to chop off the 01 and add it back
-          expect(interactionBuilder().parse(["3003foobar01"])).toEqual(["3003foobar01"]);
+          expect(interactionBuilder().parseSignature(["3003foobar01"])).toEqual(["3003foobar01"]);
         });
 
       });


### PR DESCRIPTION
Utilizes new functionality in `unchained-bitcoin` to allow a Ledger to sign a PSBT, working in `P2SH` for now.

If the PSBT is defined when we call the interaction class, we will take the provided PSBT and translate it into
- inputs
- outputs
- bip32Paths

which can be sent to the Ledger for signing.

Again, if the PSBT is defined when we call the interaction class, once the signatures come back from the device, we will return a partially signed PSBT (with the signatures returned from the device inserted and validated) instead of the normal array of signatures.