### PR TITLE
Bugfix - missed a function call replace in PR#61

### DIFF
--- a/src/trezor.js
+++ b/src/trezor.js
@@ -186,7 +186,7 @@ try {
  *     ];
  *   }
  *
- *   parse(payload) {
+ *   parsePayload(payload) {
  *     return payload.someValue;
  *   }
  *
@@ -260,7 +260,7 @@ export class TrezorInteraction extends DirectKeystoreInteraction {
    * error is thrown, it will not be caught.
    *
    * Otherwise it returns the result of passing `result.payload` to
-   * `this.parse`.
+   * `this.parsePayload`.
    *
    * @returns {Promise} handles the work of calling TrezorConnect
    */
@@ -367,7 +367,7 @@ export class TrezorGetMetadata extends TrezorInteraction {
    * @param {Object} payload - the original payload from the device response
    * @returns {Object} device metadata & features
    */
-  parse(payload) {
+  parsePayload(payload) {
     // Example result:
     //
     // {
@@ -589,7 +589,7 @@ export class TrezorExportPublicKey extends TrezorExportHDNode {
    * @param {object} payload - the original payload from the device response
    * @returns {string|Object} the (compressed) public key in hex or Object if root fingerprint requested
    */
-  parse(payload) {
+  parsePayload(payload) {
     if (this.includeXFP) {
       const {rootFingerprint, keyMaterial} = this.extractDetailsFromPayload({
         payload,
@@ -636,7 +636,7 @@ export class TrezorExportExtendedPublicKey extends TrezorExportHDNode {
    * @param {object} payload the original payload from the device response
    * @returns {string|Object} the extended public key (returns object if asked to include root fingerprint)
    */
-  parse(payload) {
+  parsePayload(payload) {
     if (this.includeXFP) {
       const {rootFingerprint, keyMaterial} = this.extractDetailsFromPayload({
         payload,
@@ -986,7 +986,7 @@ export class TrezorConfirmMultisigAddress extends TrezorInteraction {
     }
   }
 
-  parse(payload) {
+  parsePayload(payload) {
     if (!this.publicKey) {
       return payload;
     }

--- a/src/trezor.test.js
+++ b/src/trezor.test.js
@@ -93,7 +93,7 @@ describe('trezor', () => {
     it("parses metadata", () => {
 
       expect(
-        interactionBuilder().parse({
+        interactionBuilder().parsePayload({
           bootloader_hash: "5112...846e9",
           bootloader_mode: null,
           device_id: "BDF9...F198",
@@ -209,7 +209,7 @@ describe('trezor', () => {
     itThrowsAnErrorOnAnUnsuccessfulRequest(interactionBuilder);
 
     it("parses out the public key from the response payload", () => {
-      expect(interactionBuilder().parse({publicKey: "foobar"})).toEqual("foobar");
+      expect(interactionBuilder().parsePayload({publicKey: "foobar"})).toEqual("foobar");
     });
 
     it("uses TrezorConnect.getPublicKey", () => {
@@ -238,7 +238,7 @@ describe('trezor', () => {
     itThrowsAnErrorOnAnUnsuccessfulRequest(interactionBuilder);
 
     it("parses out the extended public key from the response payload", () => {
-      expect(interactionBuilder().parse({xpub: "foobar"})).toEqual("foobar");
+      expect(interactionBuilder().parsePayload({xpub: "foobar"})).toEqual("foobar");
     });
 
     it("uses TrezorConnect.getPublicKey", () => {


### PR DESCRIPTION
In https://github.com/unchained-capital/unchained-wallets/pull/61 - we removed the references to `parse` as they should not be on `DirectKeystoreInteraction`s ... forgot to replace the ones in Pubkey / Xpub Export -- this fixes that problem.