### PR TITLE
Ledger v2 signing interactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4734,7 +4734,8 @@
     },
     "node_modules/bitcoin-address-validation": {
       "version": "0.2.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bitcoin-address-validation/-/bitcoin-address-validation-0.2.9.tgz",
+      "integrity": "sha512-47/XSK0yCA5Ivbt0YK5wCXm82TJWQRfkEiVRQScug5DNvmLCLeUekY6gwtH4dr7Ms2m13Nktq6/dhvsjdut0xg==",
       "dependencies": {
         "base-x": "^3.0.6",
         "bech32": "^1.1.3",
@@ -4743,14 +4744,16 @@
     },
     "node_modules/bitcoin-address-validation/node_modules/base-x": {
       "version": "3.0.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/bitcoin-address-validation/node_modules/bech32": {
       "version": "1.1.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "node_modules/bitcoin-ops": {
       "version": "1.4.1",
@@ -4979,7 +4982,8 @@
     },
     "node_modules/bufio": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.2.0.tgz",
+      "integrity": "sha512-UlFk8z/PwdhYQTXSQQagwGAdtRI83gib2n4uy4rQnenxUM2yQi8lBDzF230BNk+3wAoZDxYRoBwVVUPgHa9MCA==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -13512,7 +13516,7 @@
     },
     "node_modules/unchained-bitcoin": {
       "version": "0.1.10",
-      "resolved": "git+ssh://git@github.com/unchained-capital/unchained-bitcoin.git#bbdcdfe65eab4ccb30dae2f2be13cc6b4b7e76d7",
+      "resolved": "git+ssh://git@github.com/unchained-capital/unchained-bitcoin.git#74c9723e9780299e1a482e0589ec753c1f9ddf1c",
       "license": "MIT",
       "dependencies": {
         "@babel/polyfill": "^7.7.0",
@@ -17220,6 +17224,8 @@
     },
     "bitcoin-address-validation": {
       "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/bitcoin-address-validation/-/bitcoin-address-validation-0.2.9.tgz",
+      "integrity": "sha512-47/XSK0yCA5Ivbt0YK5wCXm82TJWQRfkEiVRQScug5DNvmLCLeUekY6gwtH4dr7Ms2m13Nktq6/dhvsjdut0xg==",
       "requires": {
         "base-x": "^3.0.6",
         "bech32": "^1.1.3",
@@ -17228,12 +17234,16 @@
       "dependencies": {
         "base-x": {
           "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+          "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
           "requires": {
             "safe-buffer": "^5.0.1"
           }
         },
         "bech32": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+          "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
         }
       }
     },
@@ -17389,7 +17399,9 @@
       "dev": true
     },
     "bufio": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.2.0.tgz",
+      "integrity": "sha512-UlFk8z/PwdhYQTXSQQagwGAdtRI83gib2n4uy4rQnenxUM2yQi8lBDzF230BNk+3wAoZDxYRoBwVVUPgHa9MCA=="
     },
     "bytebuffer": {
       "version": "5.0.1",
@@ -22968,7 +22980,7 @@
       }
     },
     "unchained-bitcoin": {
-      "version": "git+ssh://git@github.com/unchained-capital/unchained-bitcoin.git#bbdcdfe65eab4ccb30dae2f2be13cc6b4b7e76d7",
+      "version": "git+ssh://git@github.com/unchained-capital/unchained-bitcoin.git#74c9723e9780299e1a482e0589ec753c1f9ddf1c",
       "from": "unchained-bitcoin@unchained-capital/unchained-bitcoin#ledger-v2",
       "requires": {
         "@babel/polyfill": "^7.7.0",

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import {
 } from "./hermit";
 import {
   LEDGER,
+  LEDGER_V2,
   LedgerGetMetadata,
   LedgerExportPublicKey,
   LedgerExportExtendedPublicKey,
@@ -26,6 +27,7 @@ import {
   LedgerSignMessage,
   LedgerConfirmMultisigAddress,
   LedgerRegisterWalletPolicy,
+  LedgerV2SignMultisigTransaction,
 } from "./ledger";
 import {
   TREZOR,
@@ -322,6 +324,10 @@ export function SignMultisigTransaction({
   psbt,
   keyDetails,
   returnSignatureArray = false,
+  name,
+  braid,
+  policyHmac,
+  progressCallback,
 }) {
   switch (keystore) {
     case COLDCARD:
@@ -354,6 +360,26 @@ export function SignMultisigTransaction({
         psbt,
         keyDetails,
         returnSignatureArray,
+        v2Options: {
+          name,
+          braid,
+          policyHmac,
+          psbt,
+          progressCallback,
+        },
+      });
+    case LEDGER_V2:
+      // if we can know for sure which version of the app
+      // we're going to be interacting with then we
+      // can return this interaction explicitly without
+      // waiting for catching failures and using fallbacks
+      // as in the above with v2Options
+      return new LedgerV2SignMultisigTransaction({
+        name,
+        braid,
+        policyHmac,
+        psbt,
+        progressCallback,
       });
     case TREZOR:
       return new TrezorSignMultisigTransaction({

--- a/src/ledger.test.ts
+++ b/src/ledger.test.ts
@@ -2,7 +2,12 @@
  * @jest-environment jsdom
  */
 
-import { TEST_FIXTURES, ROOT_FINGERPRINT, TESTNET } from "unchained-bitcoin";
+import {
+  TEST_FIXTURES,
+  ROOT_FINGERPRINT,
+  TESTNET,
+  Braid,
+} from "unchained-bitcoin";
 import { PENDING, ACTIVE, INFO, WARNING, ERROR } from "./interaction";
 import {
   LedgerGetMetadata,
@@ -286,8 +291,8 @@ describe("ledger", () => {
 
     const tx = TEST_FIXTURES.transactions[0];
     const keyDetails = {
-      xfp: ROOT_FINGERPRINT,
-      path: "m/45'/1'/100'",
+      fingerprint: ROOT_FINGERPRINT,
+      bip32Path: "m/45'/1'/100'",
     };
     function psbtInteractionBuilder() {
       return new LedgerSignMultisigTransaction({
@@ -446,7 +451,7 @@ describe("ledger", () => {
       policyHmac?: string,
       expected?: string,
       name = "satoshi's wallet",
-      braid = TEST_FIXTURES.braids[0],
+      braid = Braid.fromData(TEST_FIXTURES.braids[0]),
       addressIndex = 0
     ) {
       const interaction = new LedgerConfirmMultisigAddress({

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -70,7 +70,7 @@ export const LEDGER = "ledger";
 /* eslint-disable @typescript-eslint/no-var-requires */
 const TransportU2F = require("@ledgerhq/hw-transport-u2f").default;
 const TransportWebUSB = require("@ledgerhq/hw-transport-webusb").default;
-const LedgerBtc = require("@ledgerhq/hw-app-btc");
+const LedgerBtc = require("@ledgerhq/hw-app-btc").default;
 
 /**
  * Constant representing the action of pushing the left button on a

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -924,7 +924,9 @@ interface LedgerSignMultisigTransactionArguments {
 
   psbt?: string;
 
-  keyDetails?: KeyDerivation;
+  // legacy type for key details. typescript
+  // across all libraries should make this more consistent
+  keyDetails?: { xfp: string; path: string };
 
   returnSignatureArray?: boolean;
 
@@ -985,7 +987,7 @@ export class LedgerSignMultisigTransaction extends LedgerBitcoinInteraction {
 
   psbt?: string;
 
-  keyDetails?: KeyDerivation;
+  keyDetails?: { xfp: string; path: string };
 
   returnSignatureArray?: boolean;
 
@@ -1183,7 +1185,6 @@ export class LedgerSignMultisigTransaction extends LedgerBitcoinInteraction {
       if (!this.v2Options || !Object.keys(this.v2Options)) {
         throw e;
       }
-
       const interaction = new LedgerV2SignMultisigTransaction(this.v2Options);
       return interaction.run();
     }
@@ -1599,10 +1600,10 @@ type PubKey = Buffer;
 // a Buffer with the corresponding signature.
 type SignatureBuffer = Buffer;
 // return type of ledger after signing
-type LedgerSignatures = [InputIndex, PubKey, SignatureBuffer];
+export type LedgerSignatures = [InputIndex, PubKey, SignatureBuffer];
 
 export class LedgerV2SignMultisigTransaction extends LedgerBitcoinV2WithRegistrationInteraction {
-  private psbt: PsbtV2;
+  readonly psbt: PsbtV2;
 
   // optionally, a callback that will be called every time a signature is produced during
   //  * the signing process. The callback does not receive any argument, but can be used to track progress.

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -107,7 +107,19 @@ export class MultisigWalletPolicy {
     template: string;
     keyOrigins: KeyOrigin[];
   }) {
-    this.name = name;
+    // this is an unstated restriction from ledger
+    // if we don't check it here then registration will fail
+    // with an opaque error about invalid input data
+    // TODO: should this be left as full length and only
+    // abbreviated when translating to a ledger policy?
+    if (name.length > 64) {
+      console.warn(
+        `Wallet policy name too long. (${name.length}) greater than max of 64 chars.`
+      );
+      this.name = `${name.slice(0, 61)}...`;
+    } else {
+      this.name = name;
+    }
 
     validateMultisigPolicyTemplate(template);
     this.template = template;


### PR DESCRIPTION
Adds a new signing interaction for ledger v2. 

There is a standalone interaction and there is backwards compatibility built in to the existing interaction such that the new interaction will be used as a fallback.

These changes require the two dependent PRs in unchained-bitcoin to work: [PSBTv2Maps](https://github.com/unchained-capital/unchained-bitcoin/pull/62) and [this patch](https://github.com/Shadouts/unchained-bitcoin/pull/1).

New functionality can be tested out with [these updates](https://github.com/unchained-capital/caravan/pull/287) to the caravan test suite