### PR TITLE
fix: catch a failed transport.close()

### DIFF
--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -283,7 +283,11 @@ export class LedgerInteraction extends DirectKeystoreInteraction {
    */
   closeTransport() {
     return this.withTransport(async (transport) => {
-      await transport.close();
+      try {
+        await transport.close();
+      } catch (err) {
+        console.error(err);
+      }
     });
   }
 }


### PR DESCRIPTION
OS: Linux
Browser: Chrome 110.0.0.0
unchained-wallets: v.0.1.27
Keystore: Ledger

`await transport.close()` fails with error `index.js:1 DOMException: Failed to execute 'releaseInterface' on 'USBDevice': Unable to release interface.` interrupting the completion of many tests. Catching it here (and logging it) allows for tests to complete.