### PR TITLE
fix: upgrade uc-bitcoin for required psbtv2 fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "core-js": "^2.6.10",
         "punycode": "^2.1.1",
         "sha": "^3.0.0",
-        "unchained-bitcoin": "0.2.1"
+        "unchained-bitcoin": "^0.3.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.20.7",
@@ -13613,9 +13613,9 @@
       }
     },
     "node_modules/unchained-bitcoin": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.2.1.tgz",
-      "integrity": "sha512-YU9L/Q4V0GNN6vDox+KCpoX7A4A/9vN+dC5AMyYO7jS0lxXRbf8RvcsxisgW5QD1sxauuIoNwaLpbFgP1VCCJA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.3.0.tgz",
+      "integrity": "sha512-idGve5NQMf/7ZQysCabZWRTHs/+bjMuOq5HbjlGm2KHzqVsXkUTz/LjHMKFID0A5694LR69cnCN18z5YUWyMiw==",
       "dependencies": {
         "@babel/polyfill": "^7.7.0",
         "bignumber.js": "^8.1.1",
@@ -13623,7 +13623,7 @@
         "bitcoin-address-validation": "^0.2.9",
         "bitcoinjs-lib": "^5.1.10",
         "bs58check": "^2.1.2",
-        "bufio": "^1.0.6",
+        "bufio": "^1.2.0",
         "core-js": "^2.6.10"
       },
       "engines": {
@@ -23177,9 +23177,9 @@
       }
     },
     "unchained-bitcoin": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.2.1.tgz",
-      "integrity": "sha512-YU9L/Q4V0GNN6vDox+KCpoX7A4A/9vN+dC5AMyYO7jS0lxXRbf8RvcsxisgW5QD1sxauuIoNwaLpbFgP1VCCJA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.3.0.tgz",
+      "integrity": "sha512-idGve5NQMf/7ZQysCabZWRTHs/+bjMuOq5HbjlGm2KHzqVsXkUTz/LjHMKFID0A5694LR69cnCN18z5YUWyMiw==",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "bignumber.js": "^8.1.1",
@@ -23187,7 +23187,7 @@
         "bitcoin-address-validation": "^0.2.9",
         "bitcoinjs-lib": "^5.1.10",
         "bs58check": "^2.1.2",
-        "bufio": "^1.0.6",
+        "bufio": "^1.2.0",
         "core-js": "^2.6.10"
       }
     },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "core-js": "^2.6.10",
     "punycode": "^2.1.1",
     "sha": "^3.0.0",
-    "unchained-bitcoin": "0.2.1"
+    "unchained-bitcoin": "^0.3.0"
   },
   "directories": {
     "lib": "lib"

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -1671,7 +1671,7 @@ export class LedgerV2SignMultisigTransaction extends LedgerBitcoinV2WithRegistra
     const psbtVersion = getPsbtVersionNumber(psbt);
     switch (psbtVersion) {
       case 0:
-        this.psbt = PsbtV2.FromV0(psbt);
+        this.psbt = PsbtV2.FromV0(psbt, true);
         break;
       case 2:
         this.psbt = new PsbtV2(psbt);


### PR DESCRIPTION
PSBTv2 needed some fixes to handle P2WSH signing that were provided in an upgrade to unchained-bitcoin.