### PR TITLE
feat(ledger): use bip32path for ledger confirm address api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -487,8 +487,8 @@ export function ConfirmMultisigAddress({
   multisig,
   publicKey,
   name,
-  addressIndex,
   policyHmac,
+  walletConfig,
 }) {
   switch (keystore) {
     case TREZOR:
@@ -504,14 +504,14 @@ export function ConfirmMultisigAddress({
       // gets passed in but really these interactions should
       // just get a braid or something derived from it.
       const braidDetails: BraidDetails = JSON.parse(multisig.braidDetails);
-      const walletConfig = braidDetailsToWalletConfig(braidDetails);
+      const _walletConfig =
+        walletConfig || braidDetailsToWalletConfig(braidDetails);
       return new LedgerConfirmMultisigAddress({
-        ...walletConfig,
-        expected: multisig.address,
         // this is for the name of the wallet the address being confirmed is from
         name,
-        braidIndex: Number(braidDetails.index),
-        addressIndex,
+        ..._walletConfig,
+        expected: multisig.address,
+        bip32Path,
         policyHmac,
       });
     }

--- a/src/ledger.test.ts
+++ b/src/ledger.test.ts
@@ -463,16 +463,14 @@ describe("ledger", () => {
       policyHmac?: string,
       expected?: string,
       walletConfig = braidDetailsToWalletConfig(
-        (<unknown>TEST_FIXTURES.braids[0]) as BraidDetails
+        (<unknown>TEST_FIXTURES.multisigs[0].braidDetails) as BraidDetails
       ),
-      braidIndex = Number(TEST_FIXTURES.braids[0].index),
-      addressIndex = 0
+      bip32Path = TEST_FIXTURES.multisigs[0].bip32Path
     ) {
       const interaction = new LedgerConfirmMultisigAddress({
         policyHmac,
-        addressIndex,
-        braidIndex,
         expected,
+        bip32Path,
         ...walletConfig,
       });
       addInteractionMocks(interaction, mockWithApp);

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -1551,9 +1551,7 @@ interface ConfirmAddressConstructorArguments
   expected?: string;
   // whether or not to display the address to the user
   display?: boolean;
-  // the index
-  addressIndex: number;
-  braidIndex: number;
+  bip32Path: string;
 }
 
 /**
@@ -1571,13 +1569,21 @@ export class LedgerConfirmMultisigAddress extends LedgerBitcoinV2WithRegistratio
 
   constructor({
     policyHmac,
-    addressIndex,
+    // addressIndex,
     display,
     expected,
-    braidIndex,
+    bip32Path,
+    // braidIndex,
     ...walletConfig
   }: ConfirmAddressConstructorArguments) {
     super({ policyHmac, ...walletConfig });
+
+    // Get braid and address indexes from the bip32 path This should
+    // always be the final 2 elements in the path.
+    const [braidIndex, addressIndex] = bip32Path
+      .split("/")
+      .slice(-2)
+      .map((index) => Number(index));
 
     if (braidIndex !== 1 && braidIndex !== 0) {
       throw new Error(`Invalid braid index ${braidIndex}`);
@@ -1585,9 +1591,9 @@ export class LedgerConfirmMultisigAddress extends LedgerBitcoinV2WithRegistratio
 
     this.braidIndex = braidIndex;
 
-    const index = Number(addressIndex);
-    if (index < 0) throw new Error(`Invalid address index ${index}`);
-    this.addressIndex = index;
+    if (addressIndex < 0)
+      throw new Error(`Invalid address index ${addressIndex}`);
+    this.addressIndex = addressIndex;
 
     if (display) {
       this.display = display;

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -159,6 +159,19 @@ export class MultisigWalletPolicy {
       this.keyOrigins.map((ko) => ko.toString())
     );
   }
+
+  get keys() {
+    return this.keyOrigins.map((ko) => ko.toString());
+  }
+
+  static FromWalletConfig(config: MultisigWalletConfig): MultisigWalletPolicy {
+    const template = getPolicyTemplateFromWalletConfig(config);
+    const keyOrigins = getKeyOriginsFromWalletConfig(config);
+    const name = config.name || config.uuid;
+    if (!name) throw new Error("Policy template requires a name");
+
+    return new this({ name, template, keyOrigins });
+  }
 }
 
 export const validateMultisigPolicyScriptType = (template) => {


### PR DESCRIPTION
When working on confirm address on device in Caravan outside of the test suite context, I ran into issues where the API was a little clunky and didn't match with what was going on in the other keystore (trezor). This feels cleaner anyway. Ledger wants braid and address index, which is just available in bip32 path anyway. 

Companion draft PR up in Caravan that uses this functionality: https://github.com/unchained-capital/caravan/pull/296