### PR TITLE
Trim wallet name

### DIFF
--- a/src/policy.test.ts
+++ b/src/policy.test.ts
@@ -94,6 +94,13 @@ describe("MultisigWalletPolicy", () => {
       }
     }
   );
+
+  it("trims wallet name with trailing space", () => {
+    const config = (<unknown>cases[0]) as MultisigWalletConfig;
+    config.name += " ";
+    const policy = MultisigWalletPolicy.FromWalletConfig(config);
+    expect(policy.name).toEqual(config.name?.trim());
+  });
 });
 
 describe("KeyOrigin", () => {

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -103,7 +103,7 @@ export const getKeyOriginsFromWalletConfig = (
 };
 
 export class MultisigWalletPolicy {
-  private name: string;
+  readonly name: string;
 
   private template: string;
 
@@ -127,10 +127,12 @@ export class MultisigWalletPolicy {
       console.warn(
         `Wallet policy name too long. (${name.length}) greater than max of 64 chars.`
       );
-      this.name = `${name.slice(0, 61)}...`;
+      this.name = `${name.slice(0, 61)}...`.trim();
     } else {
       this.name = name;
     }
+
+    this.name = this.name.trim();
 
     validateMultisigPolicyTemplate(template);
     this.template = template;


### PR DESCRIPTION
ledger will throw an invalid data error if there is trailing whitespace. There's no need to allow this in the policy information anyway so removing when creating the policy for registration and other interactions should avoid this issue entirely. 