### PR TITLE
feat(policy): order key origins when instantiating wallet policy

### DIFF
--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -1405,8 +1405,6 @@ export abstract class LedgerBitcoinV2WithRegistrationInteraction extends LedgerB
     ...walletConfig
   }: RegistrationConstructorArguments) {
     super();
-    const keyOrigins = getKeyOriginsFromWalletConfig(walletConfig);
-    const template = getPolicyTemplateFromWalletConfig(walletConfig);
     if (policyHmac) {
       const error = validateHex(policyHmac);
       if (error) throw new Error(`Invalid policyHmac`);
@@ -1416,20 +1414,7 @@ export abstract class LedgerBitcoinV2WithRegistrationInteraction extends LedgerB
 
     this.network = walletConfig.network;
 
-    // making typescript happy and dealing
-    // with possible weird inconsistencies in configs
-    let name;
-    if (!walletConfig.name && !walletConfig.uuid) {
-      throw new Error("wallet policy requires name");
-    } else {
-      name = walletConfig.name || walletConfig.uuid;
-    }
-
-    this.walletPolicy = new MultisigWalletPolicy({
-      name,
-      keyOrigins,
-      template,
-    });
+    this.walletPolicy = MultisigWalletPolicy.FromWalletConfig(walletConfig);
   }
 
   messages() {

--- a/src/policy.test.ts
+++ b/src/policy.test.ts
@@ -107,6 +107,12 @@ describe("MultisigWalletPolicy", () => {
     expect(policy.name).toEqual(testCase.name?.trim());
   });
 
+  it("prefers uuid over name when generating from wallet config", () => {
+    testCase.uuid = "123uuid";
+    const policy = MultisigWalletPolicy.FromWalletConfig(testCase);
+    expect(policy.name).toEqual(testCase.uuid);
+  });
+
   it("always returns the same policy", () => {
     const original = { ...testCase };
     const reversed = {

--- a/src/policy.test.ts
+++ b/src/policy.test.ts
@@ -55,10 +55,6 @@ describe("validateMultisigPolicyTemplate", () => {
 });
 
 describe("MultisigWalletPolicy", () => {
-  it("can return a wallet policy", () => {
-    expect(() => POLICY_FIXTURE.policy.toLedgerPolicy()).not.toThrow();
-  });
-
   const cases = TEST_FIXTURES.multisigs.map((multisig) => ({
     ...multisig.braidDetails,
     name: multisig.description,
@@ -69,6 +65,16 @@ describe("MultisigWalletPolicy", () => {
     })),
     quorum: { requiredSigners: multisig.braidDetails.requiredSigners },
   }));
+
+  let testCase;
+
+  beforeEach(() => {
+    testCase = (<unknown>cases[0]) as MultisigWalletConfig;
+  });
+
+  it("can return a wallet policy", () => {
+    expect(() => POLICY_FIXTURE.policy.toLedgerPolicy()).not.toThrow();
+  });
 
   test.each(cases)(
     `can convert to a policy from wallet config $case.name`,
@@ -96,10 +102,24 @@ describe("MultisigWalletPolicy", () => {
   );
 
   it("trims wallet name with trailing space", () => {
-    const config = (<unknown>cases[0]) as MultisigWalletConfig;
-    config.name += " ";
-    const policy = MultisigWalletPolicy.FromWalletConfig(config);
-    expect(policy.name).toEqual(config.name?.trim());
+    testCase.name += " ";
+    const policy = MultisigWalletPolicy.FromWalletConfig(testCase);
+    expect(policy.name).toEqual(testCase.name?.trim());
+  });
+
+  it("always returns the same policy", () => {
+    const original = { ...testCase };
+    const reversed = {
+      ...testCase,
+      extendedPublicKeys: [
+        testCase.extendedPublicKeys[1],
+        testCase.extendedPublicKeys[0],
+      ],
+    };
+
+    expect(MultisigWalletPolicy.FromWalletConfig(original).keys).toEqual(
+      MultisigWalletPolicy.FromWalletConfig(reversed).keys
+    );
   });
 });
 

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -174,7 +174,8 @@ export class MultisigWalletPolicy {
   static FromWalletConfig(config: MultisigWalletConfig): MultisigWalletPolicy {
     const template = getPolicyTemplateFromWalletConfig(config);
     const keyOrigins = getKeyOriginsFromWalletConfig(config);
-    const name = config.name || config.uuid;
+    // prefer uuid to name because it's less likely to change
+    const name = config.uuid || config.name;
     if (!name) throw new Error("Policy template requires a name");
 
     return new this({ name, template, keyOrigins });


### PR DESCRIPTION
This should resolve an issue of immutability for wallet policy registrations with ledger where if a registration hmac is created with keys in one particular order and then that registration is attempted to be verified against a policy with the keys in a different order, then they won't match and the registration will fail to verify. 

This will be a minor version update since it could break any registrations that were handling the order consistently before passing it to uc-wallets and the order would be changed by the sorting here. 

I tested this in Caravan which you can see in the screenshots below. The first two are registering for the bob key without this change in the uc-wallets dependency and changing the order (which you can see in the key table) 

**First Alice (0) - Bob (1)**
![Screenshot 2023-03-27 at 9 46 46 PM](https://user-images.githubusercontent.com/4344978/228114747-43d96b20-e0e3-4e37-b7e6-e27d13fc8806.png)

**Then Bob (1) - Alice (0)**
![Screenshot 2023-03-27 at 9 44 19 PM](https://user-images.githubusercontent.com/4344978/228114775-b0bb82b8-da7a-48ef-b6a0-b6ddab7ca23d.png)

However with this change the registration for bob is the same even if the keys are in a different order.

**Then Bob (1) - Alice (0)**
![Screenshot 2023-03-27 at 9 52 31 PM](https://user-images.githubusercontent.com/4344978/228115297-7b05125e-172c-4b4b-9e61-14d4db31c578.png)

**Then Bob (1) - Alice (0)**
![Screenshot 2023-03-27 at 9 44 19 PM](https://user-images.githubusercontent.com/4344978/228114924-f32a3bca-f886-4f60-aed1-940fb2b3c625.png)

