### PR TITLE
fix: update readme with instructions on how to develop and use locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,16 @@ inter-compatibility between keystores. Implementing features which
 increase complexity and reduce inter-compatibility should be
 discouraged.
 
+### Developing locally with another app (ex. [Caravan](https://github.com/unchained-capital/caravan))
+
+If you would like to develop unchained-wallets locally while also developing an app that depends on unchained-wallets, you'll need to do a few steps:
+
+1. Change `"main": "lib/index.js"` in package.json to `"main": "src/index.ts"` This step is temporary while we convert this package to ESM.
+1. In the root of this project run `npm link`
+1. In the root of the project that depends on this package run `npm link unchained-wallets`
+
+Now when you start up your app, whatever bundler you're using (Vite, Webpack, etc.) should compile this package as well.
+
 ### Developing against local Trezor connect
 
 If for some reason you need to use a [local instance of Trezor Connect](https://wiki.trezor.io/Developers_guide:Running_Trezor_Connect_on_localhost)


### PR DESCRIPTION
This is a relatively small work around in order to get `npm link` to work with apps like Caravan. This isn't a long term solution as unchained-wallets should be upgraded to be an ESM module instead of a CJS module. Once the codebase is converted, `npm link` should be all that's needed.