### PR TITLE
Trezor: Use browser host for dev URL defaults rather than assume localhost

### DIFF
--- a/src/trezor.js
+++ b/src/trezor.js
@@ -115,9 +115,10 @@ const ENV_TREZOR_BLOCKBOOK_URL =
   env_variables.TREZOR_BLOCKBOOK_URL ||
   env_variables.REACT_APP_TREZOR_BLOCKBOOK_URL;
 
-const TREZOR_CONNECT_URL = ENV_TREZOR_CONNECT_URL || "https://localhost:8088/";
+const TREZOR_CONNECT_URL =
+  ENV_TREZOR_CONNECT_URL || `https://${window.location.hostname}:8088/`;
 const TREZOR_BLOCKBOOK_URL =
-  ENV_TREZOR_BLOCKBOOK_URL || "http://localhost:3035";
+  ENV_TREZOR_BLOCKBOOK_URL || `http://${window.location.hostname}:3035/`;
 
 const TREZOR_DEV =
   env_variables.TREZOR_DEV || env_variables.REACT_APP_TREZOR_DEV;


### PR DESCRIPTION
This change affects Trezor and changes the default from assuming localhost to assuming whatever the browser host is. Not all development environments are configured to run services at the host machine level. Using browser host as the default will allow for a stateless default which does not have limitations of a localhost configuration. For example: There may be a development environment running remotely from the browser and port mapped to forward the trezor requests to its Trezor Connect dev service.