### PR TITLE
fix: vite env vars for trezor

### DIFF
--- a/src/trezor.js
+++ b/src/trezor.js
@@ -110,10 +110,12 @@ const env_variables = { ...process.env }; // Accessing directly does not appear 
 
 const ENV_TREZOR_CONNECT_URL =
   env_variables.TREZOR_CONNECT_URL ||
-  env_variables.REACT_APP_TREZOR_CONNECT_URL;
+  env_variables.REACT_APP_TREZOR_CONNECT_UR ||
+  env_variables.VITE_TREZOR_CONNECT_URL;
 const ENV_TREZOR_BLOCKBOOK_URL =
   env_variables.TREZOR_BLOCKBOOK_URL ||
-  env_variables.REACT_APP_TREZOR_BLOCKBOOK_URL;
+  env_variables.REACT_APP_TREZOR_BLOCKBOOK_URL ||
+  env_variables.VITE_TREZOR_BLOCKBOOK_URL;
 
 const TREZOR_CONNECT_URL =
   ENV_TREZOR_CONNECT_URL || `https://${window.location.hostname}:8088/`;
@@ -121,7 +123,9 @@ const TREZOR_BLOCKBOOK_URL =
   ENV_TREZOR_BLOCKBOOK_URL || `http://${window.location.hostname}:3035/`;
 
 const TREZOR_DEV =
-  env_variables.TREZOR_DEV || env_variables.REACT_APP_TREZOR_DEV;
+  env_variables.TREZOR_DEV ||
+  env_variables.REACT_APP_TREZOR_DEV ||
+  env_variables.VITE_TREZOR_DEV;
 try {
   if (TREZOR_DEV)
     TrezorConnect.init({


### PR DESCRIPTION
This should allow unchained-wallets to continue allowing trezor connection in local development in an app running on vite using the vite prefix variation of CRA "react_app" env vars prefixes