### PR TITLE
fix: lock ledger dependencies to avoid js errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15942,14 +15942,13 @@
     "@ledgerhq/hw-transport": {
       "version": "5.51.1",
       "requires": {
-        "@ledgerhq/devices": "^5.51.1",
+        "@ledgerhq/devices": "8.0.0",
         "@ledgerhq/errors": "^5.50.0",
         "events": "^3.3.0"
       },
       "dependencies": {
         "@ledgerhq/devices": {
-          "version": "5.51.1",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.51.1.tgz",
+          "version": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.51.1.tgz",
           "integrity": "sha512-4w+P0VkbjzEXC7kv8T1GJ/9AVaP9I6uasMZ/JcdwZBS3qwvKo5A5z9uGhP5c7TvItzcmPb44b5Mw2kT+WjUuAA==",
           "requires": {
             "@ledgerhq/errors": "^5.50.0",
@@ -15995,9 +15994,9 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-6.27.12.tgz",
       "integrity": "sha512-U96UWLZIurD9ifHlm77PAgBbvDCe99DAJk64O2SdR41WRF3WaRq/pjrzCq2UvvammdCd1p7nS4zbhlse0wZplg==",
       "requires": {
-        "@ledgerhq/devices": "^8.0.0",
+        "@ledgerhq/devices": "8.0.0",
         "@ledgerhq/errors": "^6.12.3",
-        "@ledgerhq/hw-transport": "^6.28.1",
+        "@ledgerhq/hw-transport": "6.28.1",
         "@ledgerhq/logs": "^6.10.1"
       },
       "dependencies": {
@@ -16011,7 +16010,7 @@
           "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.28.1.tgz",
           "integrity": "sha512-RaZe+abn0zBIz82cE9tp7Y7aZkHWWbEaE2yJpfxT8AhFz3fx+BU0kLYzuRN9fmA7vKueNJ1MTVUCY+Ex9/CHSQ==",
           "requires": {
-            "@ledgerhq/devices": "^8.0.0",
+            "@ledgerhq/devices": "8.0.0",
             "@ledgerhq/errors": "^6.12.3",
             "events": "^3.3.0"
           }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,12 @@
     "sha": "^3.0.0",
     "unchained-bitcoin": "^1.0.0"
   },
+  "overrides": {
+    "@ledgerhq/hw-transport-webusb": {
+      "@ledgerhq/hw-transport": "6.28.1",
+      "@ledgerhq/devices": "8.0.0"
+    }
+  },
   "directories": {
     "lib": "lib"
   },


### PR DESCRIPTION
Fixes an error where when ledger interactions were being instantiated they would fail when the Transport was being created with:

`Class constructor Transport cannot be invoked without 'new'`

It's unclear what specifically was broken but in comparing situations where the error was not showing, it seemed to be when @ledgerhq/hw-transport-webusb was using an older dependency of `@legerhq/hw-transport`, working on v6.28.1 but not on the newer v6.28.8