### PR TITLE
fix(trezor): pin connect url to stable version

### DIFF
--- a/src/trezor.ts
+++ b/src/trezor.ts
@@ -109,21 +109,18 @@ const TREZOR_DEV =
   env_variables.TREZOR_DEV ||
   env_variables.REACT_APP_TREZOR_DEV ||
   env_variables.VITE_TREZOR_DEV;
+
 try {
-  if (TREZOR_DEV)
-    TrezorConnect.init({
-      connectSrc: TREZOR_CONNECT_URL,
-      lazyLoad: true, // this param prevents iframe injection until a TrezorConnect.method is called
-      manifest: {
-        email: "help@unchained-capital.com",
-        appUrl: "https://github.com/unchained-capital/unchained-wallets",
-      },
-    });
-  else
-    TrezorConnect.manifest({
-      email: "help@unchained-capital.com",
+  TrezorConnect.init({
+    connectSrc: TREZOR_DEV
+      ? TREZOR_CONNECT_URL
+      : "https://connect.trezor.io/9.1.9/", // pinning to this connect version to avoid backwards incompatible changes
+    lazyLoad: true, // this param prevents iframe injection until a TrezorConnect.method is called
+    manifest: {
+      email: "help@unchained.com",
       appUrl: "https://github.com/unchained-capital/unchained-wallets",
-    });
+    },
+  });
 } catch (e) {
   // We hit this if we run this code outside of a browser, for example
   // during unit testing.


### PR DESCRIPTION
A recent release of the trezor connect web app ([9.1.10](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/CHANGELOG.md#9110)) introduced a breaking change to trezor interactions. In caravan this can be reproduced by running through a confirm address flow which returns the following:

```
Invalid parameter "bundle/0/multisig/signatures" (= undefined): Required property
```

This change makes sure that, unless told otherwise via env vars, TrezorConnect should use a pinned version of trezor connect web app. This is probably a good idea for the long term anyway since, as this incident indicates, a change to trezor connect can cause a breaking change to any dependency without the ability to opt-in or out. 

This change was tested with a local instance of Caravan and Confirm Address on device worked. 